### PR TITLE
CE-257 Move camera to deployment after deploy

### DIFF
--- a/app/src/main/java/org/rfcx/companion/view/map/MapFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/map/MapFragment.kt
@@ -422,6 +422,15 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         handleShowDeployment(showDeployments, showGuardianDeployments)
 
         handleMarker(deploymentMarkers, locationMarkers)
+
+        if (deploymentMarkers.isNotEmpty()) {
+            val lastReport = deploymentMarkers.sortedByDescending { it.updatedAt }.first()
+            mapboxMap?.let {
+                it.moveCamera(
+                    CameraUpdateFactory.newLatLngZoom(LatLng(lastReport.latitude, lastReport.longitude), it.cameraPosition.zoom)
+                )
+            }
+        }
     }
 
     private fun getFurthestSiteFromCurrentLocation(


### PR DESCRIPTION
## ✅ DoD

- [x] Move camera to deployment after deploy https://jira.rfcx.org/browse/CE-257

## 📝 Summary

- Move camera to deployment after deploy

## 📸 Screenshots

https://user-images.githubusercontent.com/51106210/110622602-45d89500-81ce-11eb-832c-756e6511c8f8.mp4





