### PR TITLE
Radio preferences on some of preferences

### DIFF
--- a/app/src/main/java/org/rfcx/companion/util/prefs/PrefsUtils.kt
+++ b/app/src/main/java/org/rfcx/companion/util/prefs/PrefsUtils.kt
@@ -2,6 +2,7 @@ package org.rfcx.companion.util.prefs
 
 import android.content.Context
 import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -21,9 +22,22 @@ object PrefsUtils {
         val json = JsonParser.parseString(str).asJsonObject
         val keys = json.keySet()
         keys.sorted().forEach {
-            val pref = EditTextPreference(context)
+            var pref: Preference = EditTextPreference(context)
+            if (json.get(it).asString == "true" || json.get(it).asString == "false") {
+                pref = ListPreference(context)
+                pref.entryValues = arrayOf("true", "false")
+                pref.entries = arrayOf("true", "false")
+            }
+            if (it == "api_satellite_protocol") {
+                pref = ListPreference(context)
+                pref.entryValues = arrayOf("off", "sbd", "swm")
+                pref.entries = arrayOf("off", "sbd", "swm")
+            }
+
+            if (pref is EditTextPreference) {
+                pref.text = json.get(it).asString
+            }
             pref.key = it
-            pref.text = json.get(it).asString
             pref.title = it
             pref.setDefaultValue(json.get(it).asString)
             prefs.add(pref)


### PR DESCRIPTION
resolve [#443 ](https://github.com/rfcx/companion-android/issues/443)
- change true/false preferences to ListPreference to avoid user typing wrong values
- specific for `api_satellite_protocol` to be ListPreference