### PR TITLE
Predefined registration data, send registration data in deviceParameters

### DIFF
--- a/app/src/main/java/org/rfcx/companion/entity/request/GuardianDeploymentParameters.kt
+++ b/app/src/main/java/org/rfcx/companion/entity/request/GuardianDeploymentParameters.kt
@@ -4,7 +4,7 @@ data class GuardianDeploymentParameters(
     val guid: String?,
     val token: String?,
     val keystorePassphrase: String?,
-    val pinCode: String?,
+    val pin_code: String?,
     val apiMqttHost: String?,
     val apiSmsAddress: String?
 )

--- a/app/src/main/java/org/rfcx/companion/util/Common.kt
+++ b/app/src/main/java/org/rfcx/companion/util/Common.kt
@@ -5,15 +5,23 @@ import android.net.ConnectivityManager
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
+import java.net.InetAddress
+import android.net.NetworkInfo
+
+import android.net.NetworkCapabilities
+import android.os.Build
+
 
 internal fun Context?.isNetworkAvailable(): Boolean {
     if (this == null) return false
     val cm = this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    val activeNetwork = cm.activeNetworkInfo
-    if (activeNetwork != null) {
-        return activeNetwork.isConnected
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val capabilities = cm.getNetworkCapabilities(cm.activeNetwork)
+        capabilities != null && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    } else {
+        val activeNetworkInfo = cm.activeNetworkInfo
+        activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting;
     }
-    return false
 }
 
 fun Context.getIntColor(res: Int): Int {

--- a/app/src/main/java/org/rfcx/companion/util/SRandom.kt
+++ b/app/src/main/java/org/rfcx/companion/util/SRandom.kt
@@ -1,10 +1,14 @@
 package org.rfcx.companion.util
 
+import java.lang.StringBuilder
 import java.security.SecureRandom
 
 fun generateSecureRandomHash(length: Int): String {
+    val allAllowed = "abcdefghijklmnopqrstuvwxyzABCDEFGJKLMNPRSTUVWXYZ0123456789".toCharArray()
     val random = SecureRandom()
-    val bytes = ByteArray(length)
-    random.nextBytes(bytes)
-    return bytes.contentToString()
+    val stringBuilder = StringBuilder()
+    for (i in 0 until length) {
+        stringBuilder.append(allAllowed[random.nextInt(allAllowed.size)])
+    }
+    return stringBuilder.toString()
 }

--- a/app/src/main/java/org/rfcx/companion/view/deployment/guardian/GuardianDeploymentActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/guardian/GuardianDeploymentActivity.kt
@@ -310,7 +310,7 @@ class GuardianDeploymentActivity : BaseDeploymentActivity(), GuardianDeploymentP
         this.lastCheckInTime = time
     }
 
-    override fun setGuardianRegisterBody(body: GuardianRegisterResponse) {
+    override fun setGuardianRegisterBody(body: GuardianRegisterResponse?) {
         this.guardianRegister = body
     }
 
@@ -466,7 +466,7 @@ class GuardianDeploymentActivity : BaseDeploymentActivity(), GuardianDeploymentP
             guid = guid,
             token = register?.token,
             keystorePassphrase = register?.keystorePassphrase,
-            pinCode = register?.pinCode,
+            pin_code = register?.pinCode,
             apiMqttHost = register?.apiMqttHost,
             apiSmsAddress = register?.apiSmsAddress
         )

--- a/app/src/main/java/org/rfcx/companion/view/deployment/guardian/GuardianDeploymentProtocol.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/guardian/GuardianDeploymentProtocol.kt
@@ -48,7 +48,7 @@ interface GuardianDeploymentProtocol : BaseDeploymentProtocol {
     fun setSampleRate(sampleRate: Int)
     fun setOnDeployClicked()
     fun setLastCheckInTime(time: Long?)
-    fun setGuardianRegisterBody(body: GuardianRegisterResponse)
+    fun setGuardianRegisterBody(body: GuardianRegisterResponse?)
 
     fun addRegisteredToPassedCheck()
     fun removeRegisteredOnPassedCheck()


### PR DESCRIPTION
- predefined registration data and send to Guardian
- add data to `deviceParameter` and Device API can register later