### PR TITLE
fix: unblock CI — migrate synthetics to ViewBinding (Kotlin 1.8 / posthog compat)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,7 +120,10 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth:21.0.5'
 
     // Self-hosted product analytics (track.rfcx.org). Replaces Firebase Analytics.
-    implementation 'com.posthog:posthog-android:3.+'
+    // Pinned to 3.22.0 — the last posthog-android that keeps minSdk 21 (3.23+
+    // raised the library minSdk to 23, which fails the manifest merge against
+    // this app's minSdkVersion 21). Same PostHog API surface we use.
+    implementation 'com.posthog:posthog-android:3.22.0'
 
     // Kotlin Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.3.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
@@ -18,6 +17,12 @@ android {
         versionName "1.10.7"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // Self-hosted PostHog (track.rfcx.org, RFCx project). Public client token.
+        // In defaultConfig so every product flavor (incl. internalDevelop, the
+        // CI-built variant) gets them — the `mode` dimension means a flavor does
+        // not inherit fields defined only on the `common` flavor.
+        buildConfigField 'String', 'POSTHOG_API_KEY', '"phc_zQeWTDJUoE3tXnEcNZPMpC5DL353MDturnpsdtaQEQpe"'
+        buildConfigField 'String', 'POSTHOG_HOST', '"https://track.rfcx.org"'
     }
     flavorDimensions "mode"
     buildTypes {
@@ -36,9 +41,6 @@ android {
     productFlavors {
         common {
             buildConfigField 'String', 'FIREBASE_AUTH_DOMAIN', '"https://us-central1-rfcx-deployment.cloudfunctions.net/auth/"'
-            // Self-hosted PostHog (track.rfcx.org, RFCx project). Public client token.
-            buildConfigField 'String', 'POSTHOG_API_KEY', '"phc_zQeWTDJUoE3tXnEcNZPMpC5DL353MDturnpsdtaQEQpe"'
-            buildConfigField 'String', 'POSTHOG_HOST', '"https://track.rfcx.org"'
         }
         internal {
             buildConfigField 'String', 'FIREBASE_AUTH_DOMAIN', '"https://us-central1-rfcx-deployment.cloudfunctions.net/auth/"'
@@ -84,6 +86,10 @@ android {
     }
     lint {
         disable 'MissingTranslation', 'ExtraTranslation'
+    }
+    buildFeatures {
+        viewBinding true
+        buildConfig true
     }
     namespace 'org.rfcx.companion'
 }
@@ -182,5 +188,14 @@ ktlint {
     reporters {
         reporter "plain"
         reporter "checkstyle"
+    }
+}
+
+// Kotlin 1.8.10 defaults kapt stub generation to the JDK's target (17), while
+// javac stays at 1.8 (compileOptions above). Align every Kotlin compile task
+// (incl. kaptGenerateStubs) to 1.8 so their jvmTarget matches javac.
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }

--- a/app/src/main/java/org/rfcx/companion/MainActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/MainActivity.kt
@@ -15,12 +15,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
 import io.github.douglasjunior.androidSimpleTooltip.SimpleTooltip
 import io.realm.Realm
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.fragment_map.*
-import kotlinx.android.synthetic.main.layout_bottom_navigation_menu.*
-import kotlinx.android.synthetic.main.layout_search_view.*
 import kotlinx.coroutines.runBlocking
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityMainBinding
 import org.rfcx.companion.entity.CrashlyticsKey
 import org.rfcx.companion.entity.Stream
 import org.rfcx.companion.entity.isGuest
@@ -40,6 +37,7 @@ import org.rfcx.companion.widget.BottomNavigationMenuItem
 
 class MainActivity : AppCompatActivity(), MainActivityListener {
     private lateinit var mainViewModel: MainViewModel
+    private lateinit var binding: ActivityMainBinding
 
     private var currentFragment: Fragment? = null
     private val locationPermissions by lazy { LocationPermissions(this) }
@@ -100,7 +98,8 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setViewModel()
 
         firebaseCrashlytics.setCustomKey(CrashlyticsKey.EmailUser.key, this.getEmailUser())
@@ -119,10 +118,10 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
             }
         }
 
-        createLocationButton.setOnClickListener {
+        binding.createLocationButton.setOnClickListener {
             addTooltip = SimpleTooltip.Builder(this)
                 .arrowColor(ContextCompat.getColor(this, R.color.tooltipColor))
-                .anchorView(createLocationButton)
+                .anchorView(binding.createLocationButton)
                 .gravity(Gravity.TOP)
                 .modal(true)
                 .dismissOnInsideTouch(false)
@@ -155,7 +154,7 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
             setupFragments()
         }
 
-        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetContainer)
+        bottomSheetBehavior = BottomSheetBehavior.from(binding.bottomSheetContainer)
         bottomSheetBehavior.addBottomSheetCallback(object :
                 BottomSheetBehavior.BottomSheetCallback() {
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {}
@@ -187,7 +186,7 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
 
             SimpleTooltip.Builder(this)
                 .arrowColor(ContextCompat.getColor(this, R.color.backgroundColor))
-                .anchorView(createLocationButton)
+                .anchorView(binding.createLocationButton)
                 .text(getString(R.string.setup_first_device, this.getUserNickname()))
                 .gravity(Gravity.TOP)
                 .animationPadding(10F)
@@ -200,11 +199,11 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     }
 
     private fun setupBottomMenu() {
-        menuMap.setOnClickListener {
+        binding.bottomNavigationMenu.menuMap.setOnClickListener {
             onBottomMenuClick(it)
         }
 
-        menuProfile.setOnClickListener {
+        binding.bottomNavigationMenu.menuProfile.setOnClickListener {
             onBottomMenuClick(it)
         }
     }
@@ -212,16 +211,16 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     private fun onBottomMenuClick(menu: View) {
         if ((menu as BottomNavigationMenuItem).menuSelected) return
         when (menu.id) {
-            menuMap.id -> {
-                menuMap.menuSelected = true
-                menuProfile.menuSelected = false
+            binding.bottomNavigationMenu.menuMap.id -> {
+                binding.bottomNavigationMenu.menuMap.menuSelected = true
+                binding.bottomNavigationMenu.menuProfile.menuSelected = false
 
                 showMap()
             }
 
-            menuProfile.id -> {
-                menuMap.menuSelected = false
-                menuProfile.menuSelected = true
+            binding.bottomNavigationMenu.menuProfile.id -> {
+                binding.bottomNavigationMenu.menuMap.menuSelected = false
+                binding.bottomNavigationMenu.menuProfile.menuSelected = true
 
                 showProfile()
             }
@@ -249,7 +248,7 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     private fun showAboveAppbar(show: Boolean) {
         val contentContainerPaddingBottom =
             if (show) resources.getDimensionPixelSize(R.dimen.size_battery_lv_button) else 0
-        contentContainer.setPadding(0, 0, 0, contentContainerPaddingBottom)
+        binding.contentContainer.setPadding(0, 0, 0, contentContainerPaddingBottom)
     }
 
     private fun getMap(): MapFragment =
@@ -262,16 +261,16 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
 
     private fun setupFragments() {
         supportFragmentManager.beginTransaction()
-            .add(contentContainer.id, getProfile(), ProfileFragment.tag)
-            .add(contentContainer.id, getMap(), MapFragment.tag)
+            .add(binding.contentContainer.id, getProfile(), ProfileFragment.tag)
+            .add(binding.contentContainer.id, getMap(), MapFragment.tag)
             .commit()
 
-        menuMap.performClick()
+        binding.bottomNavigationMenu.menuMap.performClick()
     }
 
     override fun showSnackbar(msg: String, duration: Int) {
-        snackbar = Snackbar.make(mainRootView, msg, duration)
-        snackbar?.anchorView = createLocationButton
+        snackbar = Snackbar.make(binding.mainRootView, msg, duration)
+        snackbar?.anchorView = binding.createLocationButton
         snackbar?.show()
     }
 
@@ -305,8 +304,8 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     }
 
     override fun hideBottomAppBar() {
-        createLocationButton.visibility = View.GONE
-        bottomBar.visibility = View.GONE
+        binding.createLocationButton.visibility = View.GONE
+        binding.bottomBar.visibility = View.GONE
 
         val mapFragment = supportFragmentManager.findFragmentByTag(MapFragment.tag)
         if (mapFragment is MapFragment) {
@@ -315,8 +314,8 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     }
 
     override fun showBottomAppBar() {
-        bottomBar.visibility = View.VISIBLE
-        createLocationButton.visibility = View.VISIBLE
+        binding.bottomBar.visibility = View.VISIBLE
+        binding.createLocationButton.visibility = View.VISIBLE
 
         val mapFragment = supportFragmentManager.findFragmentByTag(MapFragment.tag)
         if (mapFragment is MapFragment) {
@@ -331,11 +330,11 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
     override fun showBottomSheet(fragment: Fragment) {
         hideSnackbar()
         hideBottomAppBar()
-        val layoutParams: CoordinatorLayout.LayoutParams = bottomSheetContainer.layoutParams as CoordinatorLayout.LayoutParams
+        val layoutParams: CoordinatorLayout.LayoutParams = binding.bottomSheetContainer.layoutParams as CoordinatorLayout.LayoutParams
         layoutParams.anchorGravity = Gravity.BOTTOM
-        bottomSheetContainer.layoutParams = layoutParams
+        binding.bottomSheetContainer.layoutParams = layoutParams
         supportFragmentManager.beginTransaction()
-            .replace(bottomSheetContainer.id, fragment, BOTTOM_SHEET)
+            .replace(binding.bottomSheetContainer.id, fragment, BOTTOM_SHEET)
             .commit()
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
@@ -352,14 +351,18 @@ class MainActivity : AppCompatActivity(), MainActivityListener {
 
     override fun onBackPressed() {
         addTooltip?.dismiss()
+        val projectRecyclerView = findViewById<View?>(R.id.projectRecyclerView)
+        val projectSwipeRefreshView = findViewById<View?>(R.id.projectSwipeRefreshView)
+        val searchLayout = findViewById<View?>(R.id.searchLayout)
+        val siteSwipeRefreshView = findViewById<View?>(R.id.siteSwipeRefreshView)
         when {
-            projectRecyclerView.visibility == View.VISIBLE -> {
+            projectRecyclerView?.visibility == View.VISIBLE -> {
                 projectRecyclerView.visibility = View.GONE
-                projectSwipeRefreshView.visibility = View.GONE
+                projectSwipeRefreshView?.visibility = View.GONE
                 setSearchBar()
             }
-            searchLayout.visibility == View.VISIBLE -> {
-                siteSwipeRefreshView.visibility = View.GONE
+            searchLayout?.visibility == View.VISIBLE -> {
+                siteSwipeRefreshView?.visibility = View.GONE
                 setSearchBar()
             }
             bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED -> {

--- a/app/src/main/java/org/rfcx/companion/MainViewModel.kt
+++ b/app/src/main/java/org/rfcx/companion/MainViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
@@ -79,12 +79,10 @@ class MainViewModel(
 
     private fun fetchLiveData() {
         streamLiveData =
-            Transformations.map(mainRepository.getAllLocateResultsAsync().asLiveData()) { it }
+            mainRepository.getAllLocateResultsAsync().asLiveData().map { it }
         streamLiveData.observeForever(streamObserve)
 
-        deploymentLiveData = Transformations.map(
-            mainRepository.getAllDeploymentLocateResultsAsync().asLiveData()
-        ) { it }
+        deploymentLiveData = mainRepository.getAllDeploymentLocateResultsAsync().asLiveData().map { it }
         deploymentLiveData.observeForever(deploymentObserve)
     }
 

--- a/app/src/main/java/org/rfcx/companion/base/ViewModelFactory.kt
+++ b/app/src/main/java/org/rfcx/companion/base/ViewModelFactory.kt
@@ -35,7 +35,7 @@ class ViewModelFactory(
     private val localDataHelper: LocalDataHelper,
     private val bleHelper: BleHelper? = null
 ) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         when {
             modelClass.isAssignableFrom(ProjectSelectViewModel::class.java) -> {
                 return ProjectSelectViewModel(

--- a/app/src/main/java/org/rfcx/companion/repo/api/TokenAuthenticator.kt
+++ b/app/src/main/java/org/rfcx/companion/repo/api/TokenAuthenticator.kt
@@ -39,7 +39,7 @@ class TokenAuthenticator(private val context: Context) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
         // No need to refresh token on no-authentication request
-        if (response.request().header("No-Authentication") != null) {
+        if (response.request.header("No-Authentication") != null) {
             return null
         }
 
@@ -53,7 +53,7 @@ class TokenAuthenticator(private val context: Context) : Authenticator {
             val token = Preferences.getInstance(context).getString(Preferences.ID_TOKEN)
 
             // execute failed request again with new access token
-            response.request().newBuilder()
+            response.request.newBuilder()
                 .header("Authorization", "Bearer $token")
                 .build()
         } else {

--- a/app/src/main/java/org/rfcx/companion/repo/ble/BleConnectDelegate.kt
+++ b/app/src/main/java/org/rfcx/companion/repo/ble/BleConnectDelegate.kt
@@ -239,8 +239,10 @@ class BleConnectDelegate(private val context: Context) {
     fun registerReceiver() {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                context.registerReceiver(gattUpdateReceiver, makeGattUpdateIntentFilter(),
-                    Context.RECEIVER_NOT_EXPORTED)
+                context.registerReceiver(
+                    gattUpdateReceiver, makeGattUpdateIntentFilter(),
+                    Context.RECEIVER_NOT_EXPORTED
+                )
             } else {
                 context.registerReceiver(gattUpdateReceiver, makeGattUpdateIntentFilter())
             }

--- a/app/src/main/java/org/rfcx/companion/service/TrackingSyncWorker.kt
+++ b/app/src/main/java/org/rfcx/companion/service/TrackingSyncWorker.kt
@@ -5,9 +5,9 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.work.*
 import io.realm.Realm
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import org.rfcx.companion.localdb.TrackingFileDb
 import org.rfcx.companion.repo.ApiManager
 import org.rfcx.companion.util.FileUtils.getMimeType
@@ -29,7 +29,7 @@ class TrackingSyncWorker(val context: Context, params: WorkerParameters) :
         tracking.forEach {
             val file = File(it.localPath)
             val mimeType = file.getMimeType()
-            val requestFile = RequestBody.create(MediaType.parse(mimeType), file)
+            val requestFile = file.asRequestBody(mimeType.toMediaTypeOrNull())
             val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
             val result = ApiManager.getInstance().getDeviceApi(context)
                 .uploadAssets(it.deploymentServerId!!, body).execute()

--- a/app/src/main/java/org/rfcx/companion/service/images/ImageSyncWorker.kt
+++ b/app/src/main/java/org/rfcx/companion/service/images/ImageSyncWorker.kt
@@ -7,9 +7,10 @@ import androidx.work.*
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import io.realm.Realm
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.rfcx.companion.localdb.DeploymentImageDb
 import org.rfcx.companion.repo.ApiManager
 import org.rfcx.companion.util.FileUtils.getMimeType
@@ -34,13 +35,13 @@ class ImageSyncWorker(val context: Context, params: WorkerParameters) :
         deploymentImage.forEach {
             val file = File(it.localPath)
             val mimeType = file.getMimeType("image/jpeg")
-            val requestFile = RequestBody.create(MediaType.parse(mimeType), storage.compressFile(context, file))
+            val requestFile = storage.compressFile(context, file).asRequestBody(mimeType.toMediaTypeOrNull())
             val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
 
             val gson = Gson()
             val obj = JsonObject()
             obj.addProperty("label", it.imageLabel)
-            val label = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), gson.toJson(obj))
+            val label = gson.toJson(obj).toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
             val result = ApiManager.getInstance().getDeviceApi(context)
                 .uploadAssets(it.deploymentServerId!!, body, label).execute()
 

--- a/app/src/main/java/org/rfcx/companion/util/AudioMothChime.kt
+++ b/app/src/main/java/org/rfcx/companion/util/AudioMothChime.kt
@@ -11,10 +11,8 @@ import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
 import android.os.Build
-
-import kotlin.math.*
-
 import java.util.Calendar
+import kotlin.math.*
 
 class AudioMothChime {
 
@@ -274,7 +272,6 @@ class AudioMothChime {
         if (xor > 0) out = out xor CRC_POLY
 
         return out
-
     }
 
     private fun createCRC16(bytes: Array<Int>): CRC16 {
@@ -295,7 +292,6 @@ class AudioMothChime {
             crc and 0xFF,
             (crc shr 8) and 0xFF
         )
-
     }
 
     /* Function to encode bytes */
@@ -315,7 +311,6 @@ class AudioMothChime {
                     bitSequence.add(HAMMING_CODE[low][x])
                     bitSequence.add(HAMMING_CODE[high][x])
                 }
-
             } else {
 
                 for (x in 0 until 8) {
@@ -323,15 +318,11 @@ class AudioMothChime {
                     val mask = (0x01 shl x)
 
                     bitSequence.add(if ((it and mask) == mask) 1 else 0)
-
                 }
-
             }
-
         }
 
         return bitSequence
-
     }
 
     /* Functions to parses notes */
@@ -356,15 +347,12 @@ class AudioMothChime {
                         )
                     )
                 }
-
             }
-
         }
 
         if (notes.size == 0) notes.add(Note())
 
         return notes
-
     }
 
     /* Functions to generate waveforms */
@@ -417,9 +405,7 @@ class AudioMothChime {
             state.x = x
 
             state.y = y
-
         }
-
     }
 
     private fun createWaveform(
@@ -464,7 +450,6 @@ class AudioMothChime {
                 )
 
                 phase *= -1.0f
-
             }
 
             /* Generate bit sequence */
@@ -504,7 +489,6 @@ class AudioMothChime {
                 )
 
                 phase *= -1.0f
-
             }
 
             /* Stop bits */
@@ -523,12 +507,10 @@ class AudioMothChime {
                 )
 
                 phase *= -1.0f
-
             }
-
         } else {
 
-            val tonePairs: Int = floor(max(MIN_TONE_DURATION, min(MAX_TONE_DURATION, duration!!)) / 1000.0f / (2 * BIT_RISE + HIGH_BIT_SUSTAIN + LOW_BIT_SUSTAIN + 2 * BIT_FALL)).toInt();
+            val tonePairs: Int = floor(max(MIN_TONE_DURATION, min(MAX_TONE_DURATION, duration!!)) / 1000.0f / (2 * BIT_RISE + HIGH_BIT_SUSTAIN + LOW_BIT_SUSTAIN + 2 * BIT_FALL)).toInt()
 
             for (i in 0 until tonePairs) {
 
@@ -557,9 +539,7 @@ class AudioMothChime {
                 )
 
                 phase *= -1.0f
-
             }
-
         }
 
         /* Reset counter */
@@ -592,7 +572,6 @@ class AudioMothChime {
                 noteDuration * note.duration,
                 noteFallDuration
             )
-
         }
 
         /* Sum the waveforms */
@@ -602,7 +581,6 @@ class AudioMothChime {
         for (i in 0 until length) waveform.add(waveform1[i] / 4.0f + waveform2[i] / 2.0f)
 
         return waveform
-
     }
 
     /* Function to generate sound */
@@ -679,11 +657,8 @@ class AudioMothChime {
                     now = Calendar.getInstance()
 
                     delay = sendTime.getTimeInMillis() - now.getTimeInMillis()
-
                 }
-
             }
-
         }
 
         println("AUDIOMOTH CHIME: Start")
@@ -691,7 +666,6 @@ class AudioMothChime {
         player?.play()
 
         println("AUDIOMOTH CHIME: Done")
-
     }
 
     /* Public chime function */
@@ -699,13 +673,11 @@ class AudioMothChime {
     fun tone(duration: Int, noteArray: Array<String>) {
 
         play(null, duration, null, noteArray)
-
     }
 
     fun chime(sendTime: Calendar?, byteArray: Array<Int>, noteArray: Array<String>) {
 
         play(sendTime, null, byteArray, noteArray)
-
     }
 
     fun stop() {
@@ -713,5 +685,4 @@ class AudioMothChime {
         player?.release()
         player = null
     }
-
 }

--- a/app/src/main/java/org/rfcx/companion/util/AudioMothChimeConnector.kt
+++ b/app/src/main/java/org/rfcx/companion/util/AudioMothChimeConnector.kt
@@ -50,11 +50,9 @@ class AudioMothChimeConnector {
         if (value) {
 
             state.bytes[byte] = state.bytes[byte] or (1 shl bit)
-
         }
 
         state.index += 1
-
     }
 
     private fun setBits(state: State, value: Int, length: Int) {
@@ -64,16 +62,14 @@ class AudioMothChimeConnector {
             val mask = (1 shl i)
 
             setBit(state, (value and mask) == mask)
-
         }
-
     }
 
     private fun encodeTime(calendar: Calendar, state: State) {
 
         /* Calculate timestamp and offset */
 
-        val timestamp: Int = ((calendar.timeInMillis + MILLISECONDS_IN_SECOND / 2 ) / MILLISECONDS_IN_SECOND).toInt()
+        val timestamp: Int = ((calendar.timeInMillis + MILLISECONDS_IN_SECOND / 2) / MILLISECONDS_IN_SECOND).toInt()
 
         val timezoneMinutes: Int =
             (calendar.timeZone.rawOffset + calendar.timeZone.dstSavings) / SECONDS_IN_MINUTE / MILLISECONDS_IN_SECOND
@@ -83,7 +79,6 @@ class AudioMothChimeConnector {
         setBits(state, timestamp, BITS_IN_INT32)
 
         setBits(state, timezoneMinutes, BITS_IN_INT16)
-
     }
 
     private fun encodeLocation(latitude: Double, longitude: Double, state: State) {
@@ -95,7 +90,6 @@ class AudioMothChimeConnector {
         setBits(state, intLatitude, BITS_IN_LATITUDE_AND_LONGITUDE)
 
         setBits(state, intLongitude, BITS_IN_LATITUDE_AND_LONGITUDE)
-
     }
 
     private fun encodeDeploymentID(deploymentID: Array<Int>, state: State) {
@@ -105,9 +99,7 @@ class AudioMothChimeConnector {
             state.bytes[state.index / BITS_PER_BYTE] = deploymentID[LENGTH_OF_DEPLOYMENT_ID - 1 - i] and 0xFF
 
             state.index += BITS_PER_BYTE
-
         }
-
     }
 
     /* Public interface function */
@@ -115,7 +107,6 @@ class AudioMothChimeConnector {
     fun playTone(duration: Int) {
 
         audioMothChime.tone(duration, arrayOf("C5:1"))
-
     }
 
     fun playTime(calendar: Calendar, latitude: Double?, longitude: Double?) {
@@ -168,7 +159,6 @@ class AudioMothChimeConnector {
             data,
             tune
         )
-
     }
 
     fun playTimeAndDeploymentID(calendar: Calendar, latitude: Double?, longitude: Double?, deploymentID: Array<Int>) {
@@ -180,7 +170,6 @@ class AudioMothChimeConnector {
             println("AUDIOMOTH CHIME CONNECTOR: Deployment ID is incorrect length")
 
             return
-
         }
 
         /* Set up array */
@@ -238,7 +227,6 @@ class AudioMothChimeConnector {
             data,
             tune
         )
-
     }
 
     fun stopPlay() {

--- a/app/src/main/java/org/rfcx/companion/util/StatusView.kt
+++ b/app/src/main/java/org/rfcx/companion/util/StatusView.kt
@@ -8,10 +8,11 @@ import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
-import kotlinx.android.synthetic.main.widget_status_view.view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.WidgetStatusViewBinding
 
 class StatusView : FrameLayout {
+    private lateinit var binding: WidgetStatusViewBinding
     private var slideOut: Animation? = null
     private var slideIn: Animation? = null
     private var handlerPostDelayed: Handler = Handler(Looper.getMainLooper())
@@ -46,23 +47,25 @@ class StatusView : FrameLayout {
         slideIn = AnimationUtils.loadAnimation(context, R.anim.slide_in)
         slideOut = AnimationUtils.loadAnimation(context, R.anim.slide_out)
 
-        View.inflate(context, R.layout.widget_status_view, this)
+        binding = WidgetStatusViewBinding.inflate(
+            android.view.LayoutInflater.from(context), this, true
+        )
         prepareView()
     }
 
     private fun prepareView() {
         this.visibility = View.GONE
-        root.background = backgroundColor
-        statusText.setTextColor(fontColor)
+        binding.root.background = backgroundColor
+        binding.statusText.setTextColor(fontColor)
     }
 
     fun onShow(msg: String) {
-        statusText.text = msg
+        binding.statusText.text = msg
         enterAnimation(this)
     }
 
     fun onShowWithDelayed(msg: String) {
-        statusText.text = msg
+        binding.statusText.text = msg
         enterAnimation(this)
         handlerPostDelayed.postDelayed({
             exitAnimation(this)

--- a/app/src/main/java/org/rfcx/companion/view/LoginActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/LoginActivity.kt
@@ -15,9 +15,9 @@ import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import androidx.appcompat.app.AppCompatDelegate.getDefaultNightMode
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.activity_login.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityLoginBinding
 import org.rfcx.companion.entity.*
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
@@ -34,10 +34,12 @@ class LoginActivity : AppCompatActivity() {
     private lateinit var loginViewModel: LoginViewModel
     private var userAuthResponse: UserAuthResponse? = null
     private val firebaseCrashlytics by lazy { Crashlytics() }
+    private lateinit var binding: ActivityLoginBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setViewModel()
         setObserver()
         setupDisplayTheme()
@@ -47,9 +49,9 @@ class LoginActivity : AppCompatActivity() {
             finish()
         }
 
-        signInButton.setOnClickListener {
-            val email = loginEmailEditText.text.toString().trim()
-            val password = loginPasswordEditText.text.toString()
+        binding.signInButton.setOnClickListener {
+            val email = binding.loginEmailEditText.text.toString().trim()
+            val password = binding.loginPasswordEditText.text.toString()
             firebaseCrashlytics.setCustomKey(CrashlyticsKey.LoginWith.key, email)
             it.hideKeyboard()
 
@@ -67,7 +69,7 @@ class LoginActivity : AppCompatActivity() {
             }
         }
 
-        googleLoginButton.setOnClickListener {
+        binding.googleLoginButton.setOnClickListener {
             loading()
             loginViewModel.loginWithGoogle(this)
         }
@@ -200,16 +202,16 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun loading(start: Boolean = true) {
-        loginGroupView.visibility = if (start) View.INVISIBLE else View.VISIBLE
-        loginProgressBar.visibility = if (start) View.VISIBLE else View.GONE
+        binding.loginGroupView.visibility = if (start) View.INVISIBLE else View.VISIBLE
+        binding.loginProgressBar.visibility = if (start) View.VISIBLE else View.GONE
     }
 
     private fun validateInput(email: String?, password: String?): Boolean {
         if (email.isNullOrEmpty()) {
-            loginEmailEditText.error = getString(R.string.pls_fill_email)
+            binding.loginEmailEditText.error = getString(R.string.pls_fill_email)
             return false
         } else if (password.isNullOrEmpty()) {
-            loginPasswordEditText.error = getString(R.string.pls_fill_password)
+            binding.loginPasswordEditText.error = getString(R.string.pls_fill_password)
             return false
         }
         return true

--- a/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothCheckListFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothCheckListFragment.kt
@@ -7,15 +7,18 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_edge_checklist.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.CheckListItem
+import org.rfcx.companion.databinding.FragmentEdgeChecklistBinding
 
 class AudioMothCheckListFragment : Fragment(), (Int, String) -> Unit {
 
     private var deploymentProtocol: AudioMothDeploymentProtocol? = null
 
     private val checkListRecyclerView by lazy { CheckListAdapter(this) }
+
+    private var _binding: FragmentEdgeChecklistBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -27,7 +30,13 @@ class AudioMothCheckListFragment : Fragment(), (Int, String) -> Unit {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_edge_checklist, container, false)
+        _binding = FragmentEdgeChecklistBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -39,7 +48,7 @@ class AudioMothCheckListFragment : Fragment(), (Int, String) -> Unit {
             it.setToolbarTitle()
         }
 
-        edgeCheckListRecyclerView.apply {
+        binding.edgeCheckListRecyclerView.apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
             adapter = checkListRecyclerView
         }
@@ -50,8 +59,8 @@ class AudioMothCheckListFragment : Fragment(), (Int, String) -> Unit {
             checkListRecyclerView.setCheckPassed(number)
         }
 
-        edgeChecklistDeployButton.isEnabled = checkListRecyclerView.isEveryCheckListPassed()
-        edgeChecklistDeployButton.setOnClickListener {
+        binding.edgeChecklistDeployButton.isEnabled = checkListRecyclerView.isEveryCheckListPassed()
+        binding.edgeChecklistDeployButton.setOnClickListener {
             deploymentProtocol?.setReadyToDeploy()
         }
     }

--- a/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothDeploymentActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothDeploymentActivity.kt
@@ -9,9 +9,9 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import io.realm.RealmList
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityDeploymentBinding
 import org.rfcx.companion.entity.*
 import org.rfcx.companion.entity.guardian.Deployment
 import org.rfcx.companion.repo.api.CoreApiHelper
@@ -49,9 +49,12 @@ class AudioMothDeploymentActivity : BaseDeploymentActivity(), AudioMothDeploymen
     private var deployments = listOf<Deployment>()
     private var sites = listOf<Stream>()
 
+    private lateinit var binding: ActivityDeploymentBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_deployment)
+        binding = ActivityDeploymentBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         setupToolbar()
@@ -106,7 +109,7 @@ class AudioMothDeploymentActivity : BaseDeploymentActivity(), AudioMothDeploymen
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayShowTitleEnabled(true)
             setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothDeploymentViewModel.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/AudioMothDeploymentViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import androidx.work.WorkInfo
 import org.rfcx.companion.R
 import org.rfcx.companion.entity.*
@@ -67,16 +67,12 @@ class AudioMothDeploymentViewModel(
         val preferences = Preferences.getInstance(context)
         val projectId = preferences.getInt(Preferences.SELECTED_PROJECT)
         siteLiveData =
-            Transformations.map(
-                audioMothDeploymentRepository.getAllResultsAsyncWithinProject(projectId)
-                    .asLiveData()
-            ) { it }
+            audioMothDeploymentRepository.getAllResultsAsyncWithinProject(projectId)
+                .asLiveData().map { it }
         siteLiveData.observeForever(siteObserve)
 
-        deploymentLiveData = Transformations.map(
-            audioMothDeploymentRepository.getAllDeploymentResultsAsyncWithinProject(projectId)
-                .asLiveData()
-        ) { it }
+        deploymentLiveData = audioMothDeploymentRepository.getAllDeploymentResultsAsyncWithinProject(projectId)
+            .asLiveData().map { it }
         deploymentLiveData.observeForever(deploymentObserve)
 
         downloadStreamsWorkInfoLiveData = DownloadStreamsWorker.workInfos(context)

--- a/app/src/main/java/org/rfcx/companion/view/deployment/BaseDeploymentActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/BaseDeploymentActivity.kt
@@ -3,9 +3,9 @@ package org.rfcx.companion.view.deployment
 import android.location.Location
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.activity_deployment.*
-import kotlinx.android.synthetic.main.toolbar_default.*
+import org.rfcx.companion.R
 import org.rfcx.companion.entity.Stream
 import org.rfcx.companion.entity.guardian.Deployment
 import org.rfcx.companion.service.DownloadStreamState
@@ -64,7 +64,7 @@ abstract class BaseDeploymentActivity :
 
     fun startFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-            .replace(contentContainer.id, fragment)
+            .replace(R.id.contentContainer, fragment)
             .commit()
     }
 
@@ -123,11 +123,11 @@ abstract class BaseDeploymentActivity :
     }
 
     override fun showToolbar() {
-        toolbar?.visibility = View.VISIBLE
+        findViewById<Toolbar?>(R.id.toolbar)?.visibility = View.VISIBLE
     }
 
     override fun hideToolbar() {
-        toolbar?.visibility = View.GONE
+        findViewById<Toolbar?>(R.id.toolbar)?.visibility = View.GONE
     }
 
     override fun setToolbarTitle() {

--- a/app/src/main/java/org/rfcx/companion/view/deployment/DeployFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/DeployFragment.kt
@@ -12,8 +12,8 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.android.synthetic.main.fragment_deploy.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentDeployBinding
 import org.rfcx.companion.entity.Device
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.*
@@ -42,6 +42,9 @@ class DeployFragment : Fragment(), ImageClickListener, GuidelineButtonClickListe
 
     private var audioMothDeploymentProtocol: BaseDeploymentProtocol? = null
     private var songMeterDeploymentProtocol: BaseDeploymentProtocol? = null
+
+    private var _binding: FragmentDeployBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -120,7 +123,7 @@ class DeployFragment : Fragment(), ImageClickListener, GuidelineButtonClickListe
     }
 
     private fun setupImageRecycler() {
-        attachImageRecycler.apply {
+        binding.attachImageRecycler.apply {
             adapter = getImageAdapter()
             layoutManager = GridLayoutManager(context, 3)
         }
@@ -131,7 +134,13 @@ class DeployFragment : Fragment(), ImageClickListener, GuidelineButtonClickListe
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_deploy, container, false)
+        _binding = FragmentDeployBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -145,7 +154,7 @@ class DeployFragment : Fragment(), ImageClickListener, GuidelineButtonClickListe
         setupImageRecycler()
         updatePhotoTakenNumber()
 
-        finishButton.setOnClickListener {
+        binding.finishButton.setOnClickListener {
             val existing = getImageAdapter().getExistingImages()
             val missing = getImageAdapter().getMissingImages()
             if (missing.isEmpty()) {
@@ -193,7 +202,7 @@ class DeployFragment : Fragment(), ImageClickListener, GuidelineButtonClickListe
 
     private fun updatePhotoTakenNumber() {
         val number = getImageAdapter().getExistingImages().size
-        photoTakenTextView.text =
+        binding.photoTakenTextView.text =
             getString(R.string.photo_taken, number, getImageAdapter().itemCount)
     }
 

--- a/app/src/main/java/org/rfcx/companion/view/deployment/ImageAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/ImageAdapter.kt
@@ -8,9 +8,8 @@ import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_photo_advise.view.*
 import org.rfcx.companion.BuildConfig
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemPhotoAdviseBinding
 import org.rfcx.companion.extension.setDeploymentImage
 import org.rfcx.companion.util.getIdToken
 import java.io.Serializable
@@ -140,9 +139,9 @@ class ImageAdapter(
         parent: ViewGroup,
         viewType: Int
     ): ImageAdapterViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_photo_advise, parent, false)
-        return ImageAdapterViewHolder(view)
+        val binding =
+            ItemPhotoAdviseBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ImageAdapterViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ImageAdapterViewHolder, position: Int) {
@@ -164,10 +163,10 @@ class ImageAdapter(
         }
     }
 
-    inner class ImageAdapterViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val placeHolderButton: AppCompatButton = itemView.placeHolderButton
-        val imageView: ImageView = itemView.image
-        val deleteButton: ImageButton = itemView.deleteImageButton
+    inner class ImageAdapterViewHolder(binding: ItemPhotoAdviseBinding) : RecyclerView.ViewHolder(binding.root) {
+        val placeHolderButton: AppCompatButton = binding.placeHolderButton
+        val imageView: ImageView = binding.image
+        val deleteButton: ImageButton = binding.deleteImageButton
 
         fun bind(image: Image) {
             if (image.path == null) {

--- a/app/src/main/java/org/rfcx/companion/view/deployment/locate/MapPickerFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/locate/MapPickerFragment.kt
@@ -23,9 +23,8 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
-import kotlinx.android.synthetic.main.fragment_map_picker.*
-import kotlinx.android.synthetic.main.layout_search_view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentMapPickerBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.Analytics
 import org.rfcx.companion.util.DefaultSetupMap
@@ -54,6 +53,9 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
 
     private val analytics by lazy { context?.let { Analytics(it) } }
 
+    private var _binding: FragmentMapPickerBinding? = null
+    private val binding get() = _binding!!
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         mapPickerProtocol = context as MapPickerProtocol
@@ -70,7 +72,13 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_map_picker, container, false)
+        _binding = FragmentMapPickerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -87,7 +95,7 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
 
         showLoading(true)
 
-        selectButton.setOnClickListener {
+        binding.selectButton.setOnClickListener {
             val currentCameraPosition = map.cameraPosition.target
             analytics?.trackSelectLocationEvent()
             mapPickerProtocol?.onSelectedLocation(
@@ -98,7 +106,7 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
             )
         }
 
-        currentLocationButton.setOnClickListener {
+        binding.currentLocationButton.setOnClickListener {
             selectedLocation = currentUserLocation
             selectedLocation?.let {
                 val latLng = LatLng(it.latitude, it.longitude)
@@ -120,9 +128,9 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun showLoading(isLoading: Boolean) {
-        fabProgress.visibility = if (isLoading) View.VISIBLE else View.INVISIBLE
-        currentLocationButton.isEnabled = !isLoading
-        currentLocationButton.supportImageTintList =
+        binding.fabProgress.visibility = if (isLoading) View.VISIBLE else View.INVISIBLE
+        binding.currentLocationButton.isEnabled = !isLoading
+        binding.currentLocationButton.supportImageTintList =
             if (isLoading) resources.getColorStateList(R.color.gray_30) else resources.getColorStateList(
                 R.color.colorPrimary
             )
@@ -186,7 +194,7 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
     private fun setLatLogLabel(location: LatLng) {
         context?.let {
             val latLng = "${location.latitude.latitudeCoordinates(it)}, ${location.longitude.longitudeCoordinates(it)}"
-            locationTextView.text = latLng
+            binding.locationTextView.text = latLng
         }
     }
 
@@ -196,43 +204,43 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setupSearch() {
-        searchLayoutSearchEditText.visibility = View.GONE
-        searchLayoutCardView.setOnClickListener {
-            searchLayoutSearchEditText.clearFocus()
+        binding.searchView.searchLayoutSearchEditText.visibility = View.GONE
+        binding.searchView.searchLayoutCardView.setOnClickListener {
+            binding.searchView.searchLayoutSearchEditText.clearFocus()
         }
 
-        searchLayoutSearchEditText.setOnFocusChangeListener { _, hasFocus ->
+        binding.searchView.searchLayoutSearchEditText.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                searchLayout.setBackgroundResource(R.color.backgroundColor)
-                searchViewActionLeftButton.visibility = View.VISIBLE
+                binding.searchView.searchLayout.setBackgroundResource(R.color.backgroundColor)
+                binding.searchView.searchViewActionLeftButton.visibility = View.VISIBLE
                 editLocationActivityListener?.hideAppbar()
                 showSearchFragment()
             } else {
-                searchLayout.setBackgroundResource(R.color.transparent)
-                searchViewActionLeftButton.visibility = View.GONE
-                searchViewActionRightButton.visibility = View.GONE
+                binding.searchView.searchLayout.setBackgroundResource(R.color.transparent)
+                binding.searchView.searchViewActionLeftButton.visibility = View.GONE
+                binding.searchView.searchViewActionRightButton.visibility = View.GONE
                 editLocationActivityListener?.showAppbar()
                 hideSearchFragment()
             }
         }
 
-        searchViewActionRightButton.setOnClickListener {
-            searchLayoutSearchEditText.text = null
+        binding.searchView.searchViewActionRightButton.setOnClickListener {
+            binding.searchView.searchLayoutSearchEditText.text = null
         }
 
         childFragmentManager.addOnBackStackChangedListener {
             if (childFragmentManager.backStackEntryCount == 0) {
-                searchLayoutSearchEditText.clearFocus()
+                binding.searchView.searchLayoutSearchEditText.clearFocus()
             }
         }
 
-        searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
+        binding.searchView.searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
             var timer: Timer = Timer()
             override fun afterTextChanged(s: Editable?) {
                 if (s.isNullOrEmpty()) {
-                    searchViewActionRightButton.visibility = View.GONE
+                    binding.searchView.searchViewActionRightButton.visibility = View.GONE
                 } else {
-                    searchViewActionRightButton.visibility = View.VISIBLE
+                    binding.searchView.searchViewActionRightButton.visibility = View.VISIBLE
                 }
                 timer.cancel()
                 timer = Timer()
@@ -252,17 +260,17 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
             }
         })
 
-        searchLayoutSearchEditText.setOnEditorActionListener { _, actionId, _ ->
+        binding.searchView.searchLayoutSearchEditText.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 val imm: InputMethodManager? =
                     context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-                imm?.hideSoftInputFromWindow(searchLayoutSearchEditText.windowToken, 0)
+                imm?.hideSoftInputFromWindow(binding.searchView.searchLayoutSearchEditText.windowToken, 0)
                 return@setOnEditorActionListener true
             }
             false
         }
 
-        searchViewActionLeftButton.setOnClickListener {
+        binding.searchView.searchViewActionLeftButton.setOnClickListener {
             clearSearchInputAndHideSoftInput()
         }
     }
@@ -271,8 +279,8 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
         childFragmentManager.beginTransaction().apply {
             setCustomAnimations(R.anim.fragment_slide_in_up, 0, 0, R.anim.fragment_slide_out_up)
         }.addToBackStack(SearchResultFragment.tag).replace(
-            searchResultListContainer.id,
-            SearchResultFragment.newInstance(searchLayoutSearchEditText.text?.toString()),
+            binding.searchResultListContainer.id,
+            SearchResultFragment.newInstance(binding.searchView.searchLayoutSearchEditText.text?.toString()),
             SearchResultFragment.tag
         ).commitAllowingStateLoss()
     }
@@ -290,9 +298,9 @@ class MapPickerFragment : Fragment(), OnMapReadyCallback {
     private fun clearSearchInputAndHideSoftInput() {
         val imm: InputMethodManager? =
             context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-        imm?.hideSoftInputFromWindow(searchLayoutSearchEditText.windowToken, 0)
-        searchLayoutSearchEditText.text = null
-        searchLayoutSearchEditText.clearFocus()
+        imm?.hideSoftInputFromWindow(binding.searchView.searchLayoutSearchEditText.windowToken, 0)
+        binding.searchView.searchLayoutSearchEditText.text = null
+        binding.searchView.searchLayoutSearchEditText.clearFocus()
     }
 
     companion object {

--- a/app/src/main/java/org/rfcx/companion/view/deployment/locate/SearchLocationResultAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/locate/SearchLocationResultAdapter.kt
@@ -1,16 +1,14 @@
 package org.rfcx.companion.view.deployment.locate
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_search_location_result.view.*
-import kotlinx.android.synthetic.main.item_search_location_result_error.view.*
-import org.rfcx.companion.R
 import org.rfcx.companion.adapter.BaseListItem
+import org.rfcx.companion.databinding.ItemSearchLocationResultBinding
+import org.rfcx.companion.databinding.ItemSearchLocationResultErrorBinding
 import org.rfcx.companion.util.latitudeCoordinates
 import org.rfcx.companion.util.longitudeCoordinates
 
@@ -84,9 +82,9 @@ class SearchLocationResultDiffCallback : DiffUtil.ItemCallback<BaseListItem>() {
 }
 
 class SearchLocationViewHolder(
-    itemView: View,
+    private val binding: ItemSearchLocationResultBinding,
     private val onItemClick: ((position: Int, latitude: Double, longitude: Double, placeName: String) -> Unit)?
-) : RecyclerView.ViewHolder(itemView) {
+) : RecyclerView.ViewHolder(binding.root) {
 
     companion object {
         const val itemViewType = 1
@@ -95,8 +93,8 @@ class SearchLocationViewHolder(
             onItemClick: ((position: Int, latitude: Double, longitude: Double, placeName: String) -> Unit)?
         ): SearchLocationViewHolder {
             return SearchLocationViewHolder(
-                LayoutInflater.from(parent.context).inflate(
-                    R.layout.item_search_location_result,
+                ItemSearchLocationResultBinding.inflate(
+                    LayoutInflater.from(parent.context),
                     parent,
                     false
                 ),
@@ -106,12 +104,12 @@ class SearchLocationViewHolder(
     }
 
     fun bind(item: SearchResult) {
-        itemView.placeNameTextView.text = item.placeName
+        binding.placeNameTextView.text = item.placeName
         val locationText =
             "${item.latitude.latitudeCoordinates(itemView.context)}, ${item.longitude.longitudeCoordinates(
                 itemView.context
             )}"
-        itemView.placeLocationTextView.text = locationText
+        binding.placeLocationTextView.text = locationText
 
         itemView.setOnClickListener {
             onItemClick?.invoke(adapterPosition, item.latitude, item.longitude, item.placeName)
@@ -119,14 +117,14 @@ class SearchLocationViewHolder(
     }
 }
 
-class SearchLocationErrorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+class SearchLocationErrorViewHolder(private val binding: ItemSearchLocationResultErrorBinding) : RecyclerView.ViewHolder(binding.root) {
 
     companion object {
         const val itemViewType = 2
         fun create(parent: ViewGroup): SearchLocationErrorViewHolder {
             return SearchLocationErrorViewHolder(
-                LayoutInflater.from(parent.context).inflate(
-                    R.layout.item_search_location_result_error,
+                ItemSearchLocationResultErrorBinding.inflate(
+                    LayoutInflater.from(parent.context),
                     parent,
                     false
                 )
@@ -136,10 +134,10 @@ class SearchLocationErrorViewHolder(itemView: View) : RecyclerView.ViewHolder(it
 
     fun bind(error: SearchResultError) {
         if (error.icon != 0) {
-            itemView.searchErrorIconImageView.setImageResource(error.icon)
+            binding.searchErrorIconImageView.setImageResource(error.icon)
         }
-        itemView.searchErrorTitleTextView.text = error.title
-        itemView.searchErrorMessageTextView.text = error.message
+        binding.searchErrorTitleTextView.text = error.title
+        binding.searchErrorMessageTextView.text = error.message
     }
 }
 

--- a/app/src/main/java/org/rfcx/companion/view/deployment/locate/SearchResultFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/locate/SearchResultFragment.kt
@@ -6,8 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.layout_search_result.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.LayoutSearchResultBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.Analytics
 
@@ -18,6 +18,9 @@ class SearchResultFragment : Fragment() {
 
     private var searchQuery: String? = null
 
+    private var _binding: LayoutSearchResultBinding? = null
+    private val binding get() = _binding!!
+
     private val latLngRegex =
         Regex("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)\$")
 
@@ -26,7 +29,13 @@ class SearchResultFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.layout_search_result, container, false)
+        _binding = LayoutSearchResultBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -60,7 +69,7 @@ class SearchResultFragment : Fragment() {
     }
 
     private fun setupAdapter() {
-        searchLocationRecyclerView.apply {
+        binding.searchLocationRecyclerView.apply {
             setHasFixedSize(false)
             layoutManager = LinearLayoutManager(context)
             adapter = searchLocationResultAdapter

--- a/app/src/main/java/org/rfcx/companion/view/deployment/location/DetailDeploymentSiteFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/location/DetailDeploymentSiteFragment.kt
@@ -27,17 +27,9 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.maps.android.SphericalUtil
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.altitudeValue
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.changeProjectTextView
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.coordinatesValueTextView
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.currentLocate
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.locationGroupValueTextView
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.nextButton
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.siteValueTextView
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.viewMapBox
-import kotlinx.android.synthetic.main.fragment_detail_deployment_site.withinTextView
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentDetailDeploymentSiteBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.entity.Stream
@@ -86,6 +78,9 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
     private var userLocation: Location? = null
     private var pinLocation: LatLng? = null
 
+    private var _binding: FragmentDetailDeploymentSiteBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
@@ -121,7 +116,13 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_detail_deployment_site, container, false)
+        _binding = FragmentDetailDeploymentSiteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onAttach(context: Context) {
@@ -138,7 +139,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
         mapFragment.getMapAsync(this)
         updateView()
 
-        changeProjectTextView.setOnClickListener {
+        binding.changeProjectTextView.setOnClickListener {
             context?.let { it1 ->
                 ProjectActivity.startActivity(
                     it1, this.project?.id ?: -1, Screen.DETAIL_DEPLOYMENT_SITE.id
@@ -147,7 +148,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
             }
         }
 
-        nextButton.setOnClickListener {
+        binding.nextButton.setOnClickListener {
             analytics?.trackSaveLocationEvent(Screen.LOCATION.id)
             this.altitude = currentUserLocation?.altitude ?: 0.0
             getLastLocation()
@@ -158,7 +159,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
             }
         }
 
-        currentLocate.setOnClickListener {
+        binding.currentLocate.setOnClickListener {
             setWithinText()
             isUseCurrentLocate = true
             if (isCreateNew) {
@@ -174,7 +175,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
             }
         }
 
-        viewMapBox.setOnClickListener {
+        binding.viewMapBox.setOnClickListener {
             deploymentProtocol?.let {
                 getLastLocation()
                 val siteLocation = userLocation
@@ -242,7 +243,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun createSite() {
-        val name = siteValueTextView.text.toString()
+        val name = binding.siteValueTextView.text.toString()
         userLocation?.let {
             val locate = Stream(
                 name = name,
@@ -322,17 +323,17 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
                 setLatLngLabel(it.toLatLng(), alt ?: 0.0)
                 pinLocation = it.toLatLng()
             }
-            locationGroupValueTextView.text = site?.project?.name ?: getString(R.string.none)
+            binding.locationGroupValueTextView.text = site?.project?.name ?: getString(R.string.none)
         }
-        siteValueTextView.text = siteName
-        changeProjectTextView.visibility = View.GONE
+        binding.siteValueTextView.text = siteName
+        binding.changeProjectTextView.visibility = View.GONE
     }
 
     private fun setLatLngLabel(location: LatLng, altitude: Double) {
         context?.let {
             val latLng = "${location.latitude.latitudeCoordinates(it)}, ${location.longitude.longitudeCoordinates(it)}"
-            coordinatesValueTextView.text = latLng
-            altitudeValue.text = altitude.setFormatLabel()
+            binding.coordinatesValueTextView.text = latLng
+            binding.altitudeValue.text = altitude.setFormatLabel()
         }
     }
 
@@ -430,17 +431,17 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setWithinText() {
-        withinTextView.text = getString(R.string.within)
-        withinTextView.setCompoundDrawablesWithIntrinsicBounds(
+        binding.withinTextView.text = getString(R.string.within)
+        binding.withinTextView.setCompoundDrawablesWithIntrinsicBounds(
             R.drawable.ic_checklist_passed, 0, 0, 0
         )
     }
 
     private fun setNotWithinText(distance: String) {
-        withinTextView.setCompoundDrawablesWithIntrinsicBounds(
+        binding.withinTextView.setCompoundDrawablesWithIntrinsicBounds(
             R.drawable.ic_checklist_cross, 0, 0, 0
         )
-        withinTextView.text = getString(R.string.more_than, distance)
+        binding.withinTextView.text = getString(R.string.more_than, distance)
     }
 
     override fun onResume() {
@@ -452,7 +453,7 @@ class DetailDeploymentSiteFragment : Fragment(), OnMapReadyCallback {
         val selectedEditProject = audioMothDeploymentViewModel.getProjectById(editProjectId)
 
         this.project = selectedEditProject ?: selectedProject
-        locationGroupValueTextView.text = this.project?.name
+        binding.locationGroupValueTextView.text = this.project?.name
     }
 
     private fun bitmapFromVector(context: Context, vectorResId: Int): BitmapDescriptor {

--- a/app/src/main/java/org/rfcx/companion/view/deployment/location/SetDeploymentSiteFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/location/SetDeploymentSiteFragment.kt
@@ -12,10 +12,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_set_deployment_site.*
-import kotlinx.android.synthetic.main.layout_search_view.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentSetDeploymentSiteBinding
 import org.rfcx.companion.entity.Stream
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
@@ -48,6 +47,9 @@ class SetDeploymentSiteFragment :
     private var searchItem: MenuItem? = null
     private var latitude: Double = 0.0
     private var longitude: Double = 0.0
+
+    private var _binding: FragmentSetDeploymentSiteBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -84,7 +86,13 @@ class SetDeploymentSiteFragment :
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_set_deployment_site, container, false)
+        _binding = FragmentSetDeploymentSiteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -104,33 +112,33 @@ class SetDeploymentSiteFragment :
         this.lastSyncingInfo = status
         when (status) {
             SyncInfo.Starting, SyncInfo.Uploading -> {
-                statusSiteView.onShow(getString(R.string.sites_downloading))
+                binding.statusSiteView.onShow(getString(R.string.sites_downloading))
             }
             SyncInfo.Uploaded -> {
-                statusSiteView.onShowWithDelayed(getString(R.string.sites_synced))
+                binding.statusSiteView.onShowWithDelayed(getString(R.string.sites_synced))
             }
             else -> {
-                statusSiteView.onShowWithDelayed(getString(R.string.format_deploy_waiting_network))
+                binding.statusSiteView.onShowWithDelayed(getString(R.string.format_deploy_waiting_network))
             }
         }
     }
 
     private fun setEditText() {
-        searchLayout.visibility = View.VISIBLE
-        searchLayoutSearchEditText.showKeyboard()
-        searchLayoutSearchEditText.requestFocus()
-        searchViewActionRightButton.visibility = View.VISIBLE
-        searchLayoutSearchEditText.hint = context?.getString(R.string.search_or_create_box_hint)
+        binding.searchView.searchLayout.visibility = View.VISIBLE
+        binding.searchView.searchLayoutSearchEditText.showKeyboard()
+        binding.searchView.searchLayoutSearchEditText.requestFocus()
+        binding.searchView.searchViewActionRightButton.visibility = View.VISIBLE
+        binding.searchView.searchLayoutSearchEditText.hint = context?.getString(R.string.search_or_create_box_hint)
 
-        searchViewActionRightButton.setOnClickListener {
-            if (searchLayoutSearchEditText.text.isNullOrBlank()) {
+        binding.searchView.searchViewActionRightButton.setOnClickListener {
+            if (binding.searchView.searchLayoutSearchEditText.text.isNullOrBlank()) {
                 it.hideKeyboard()
             } else {
-                searchLayoutSearchEditText.text = null
+                binding.searchView.searchLayoutSearchEditText.text = null
             }
         }
 
-        searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
+        binding.searchView.searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {
                 searchItem?.isVisible = s?.length == 0
                 if (s?.length == 0) {
@@ -143,7 +151,7 @@ class SetDeploymentSiteFragment :
                             it.stream.name.toLowerCase().contains(text)
                         }
                     )
-                    noResultFound.visibility = View.GONE
+                    binding.noResultFound.visibility = View.GONE
                     val createNew = arrayListOf(
                         SiteWithLastDeploymentItem(
                             Stream(
@@ -193,7 +201,7 @@ class SetDeploymentSiteFragment :
     }
 
     private fun setupAdapter() {
-        existedRecyclerView.apply {
+        binding.existedRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = existedSiteAdapter
         }
@@ -220,7 +228,7 @@ class SetDeploymentSiteFragment :
     }
 
     private fun setSwipeSite() {
-        siteSwipeRefreshView.apply {
+        binding.siteSwipeRefreshView.apply {
             setOnRefreshListener {
                 val projectId = preferences.getInt(Preferences.SELECTED_PROJECT)
                 val project = audioMothDeploymentViewModel.getProjectById(projectId)

--- a/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/SongMeterCheckListFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/SongMeterCheckListFragment.kt
@@ -7,14 +7,17 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_songmeter_check_list.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.CheckListItem
+import org.rfcx.companion.databinding.FragmentSongmeterCheckListBinding
 import org.rfcx.companion.view.deployment.CheckListAdapter
 
 class SongMeterCheckListFragment : Fragment(), (Int, String) -> Unit {
     private var deploymentProtocol: SongMeterDeploymentProtocol? = null
     private val checkListRecyclerView by lazy { CheckListAdapter(this) }
+
+    private var _binding: FragmentSongmeterCheckListBinding? = null
+    private val binding get() = _binding!!
 
     companion object {
         @JvmStatic
@@ -32,7 +35,13 @@ class SongMeterCheckListFragment : Fragment(), (Int, String) -> Unit {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_songmeter_check_list, container, false)
+        _binding = FragmentSongmeterCheckListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -44,7 +53,7 @@ class SongMeterCheckListFragment : Fragment(), (Int, String) -> Unit {
     }
 
     private fun setupAdapter() {
-        songMeterCheckListRecyclerView.apply {
+        binding.songMeterCheckListRecyclerView.apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
             adapter = checkListRecyclerView
         }
@@ -57,8 +66,8 @@ class SongMeterCheckListFragment : Fragment(), (Int, String) -> Unit {
     }
 
     private fun setupButton() {
-        songMeterChecklistDeployButton.isEnabled = checkListRecyclerView.isEveryCheckListPassed()
-        songMeterChecklistDeployButton.setOnClickListener {
+        binding.songMeterChecklistDeployButton.isEnabled = checkListRecyclerView.isEveryCheckListPassed()
+        binding.songMeterChecklistDeployButton.setOnClickListener {
             deploymentProtocol?.setReadyToDeploy()
         }
     }

--- a/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/SongMeterDeploymentActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/SongMeterDeploymentActivity.kt
@@ -13,9 +13,9 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.gson.Gson
 import io.realm.RealmList
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivitySongMeterDeploymentBinding
 import org.rfcx.companion.entity.*
 import org.rfcx.companion.entity.guardian.Deployment
 import org.rfcx.companion.repo.api.CoreApiHelper
@@ -65,6 +65,8 @@ class SongMeterDeploymentActivity : BaseDeploymentActivity(), SongMeterDeploymen
 
     private var menuAll: Menu? = null
 
+    private lateinit var binding: ActivitySongMeterDeploymentBinding
+
     companion object {
         const val TAG = "SongMeterDeploymentActivity"
         const val loadingDialogTag = "LoadingDialog"
@@ -79,7 +81,8 @@ class SongMeterDeploymentActivity : BaseDeploymentActivity(), SongMeterDeploymen
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_song_meter_deployment)
+        binding = ActivitySongMeterDeploymentBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         setupToolbar()
@@ -355,11 +358,11 @@ class SongMeterDeploymentActivity : BaseDeploymentActivity(), SongMeterDeploymen
     }
 
     override fun showToolbar() {
-        toolbar?.visibility = View.VISIBLE
+        binding.toolbarLayout.toolbar.visibility = View.VISIBLE
     }
 
     override fun hideToolbar() {
-        toolbar?.visibility = View.GONE
+        binding.toolbarLayout.toolbar.visibility = View.GONE
     }
 
     override fun setMenuToolbar(isVisibility: Boolean) {
@@ -383,7 +386,7 @@ class SongMeterDeploymentActivity : BaseDeploymentActivity(), SongMeterDeploymen
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayShowTitleEnabled(true)
             setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/detect/SongMeterAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/detect/SongMeterAdapter.kt
@@ -1,12 +1,11 @@
 package org.rfcx.companion.view.deployment.songmeter.detect
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_songmeter.view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemSongmeterBinding
 import org.rfcx.companion.entity.songmeter.Advertisement
 
 class SongMeterAdapter(private val onRecorderClickListener: (Advertisement) -> Unit) : RecyclerView.Adapter<SongMeterAdapter.SongMeterViewHolder>() {
@@ -25,8 +24,8 @@ class SongMeterAdapter(private val onRecorderClickListener: (Advertisement) -> U
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SongMeterViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_songmeter, parent, false)
-        return SongMeterViewHolder(view)
+        val binding = ItemSongmeterBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return SongMeterViewHolder(binding)
     }
 
     override fun getItemCount(): Int = items.size
@@ -38,9 +37,9 @@ class SongMeterAdapter(private val onRecorderClickListener: (Advertisement) -> U
         holder.bind(songMeter)
 
         if (selectedPosition == position) {
-            holder.itemView.apply {
-                songMeterPrefixesTextView.setTextColor(ContextCompat.getColor(this.context, R.color.colorPrimary))
-                songMeterSerialNumberTextView.setTextColor(ContextCompat.getColor(this.context, R.color.colorPrimary))
+            holder.binding.apply {
+                songMeterPrefixesTextView.setTextColor(ContextCompat.getColor(root.context, R.color.colorPrimary))
+                songMeterSerialNumberTextView.setTextColor(ContextCompat.getColor(root.context, R.color.colorPrimary))
                 songMeterPrefixesTextView.setCompoundDrawablesWithIntrinsicBounds(
                     0,
                     0,
@@ -49,9 +48,9 @@ class SongMeterAdapter(private val onRecorderClickListener: (Advertisement) -> U
                 )
             }
         } else {
-            holder.itemView.apply {
-                songMeterPrefixesTextView.setTextColor(ContextCompat.getColor(this.context, R.color.text_secondary))
-                songMeterSerialNumberTextView.setTextColor(ContextCompat.getColor(this.context, R.color.text_secondary))
+            holder.binding.apply {
+                songMeterPrefixesTextView.setTextColor(ContextCompat.getColor(root.context, R.color.text_secondary))
+                songMeterSerialNumberTextView.setTextColor(ContextCompat.getColor(root.context, R.color.text_secondary))
                 songMeterPrefixesTextView.setCompoundDrawablesWithIntrinsicBounds(
                     0,
                     0,
@@ -68,9 +67,9 @@ class SongMeterAdapter(private val onRecorderClickListener: (Advertisement) -> U
         }
     }
 
-    inner class SongMeterViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val prefixes = itemView.songMeterPrefixesTextView
-        private val serialName = itemView.songMeterSerialNumberTextView
+    inner class SongMeterViewHolder(val binding: ItemSongmeterBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val prefixes = binding.songMeterPrefixesTextView
+        private val serialName = binding.songMeterSerialNumberTextView
 
         fun bind(ads: Advertisement) {
             prefixes.text = ads.prefixes

--- a/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/detect/SongMeterDetectFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/detect/SongMeterDetectFragment.kt
@@ -13,9 +13,9 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.android.synthetic.main.fragment_songmeter_detect.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentSongmeterDetectBinding
 import org.rfcx.companion.entity.songmeter.Advertisement
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
@@ -42,6 +42,9 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
     private var setPrefixes = ""
     private var currentStep = 1
     private var isReadyToSet = true
+
+    private var _binding: FragmentSongmeterDetectBinding? = null
+    private val binding get() = _binding!!
 
     private val requestMultiplePermissions =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
@@ -75,7 +78,13 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_songmeter_detect, container, false)
+        _binding = FragmentSongmeterDetectBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -89,12 +98,12 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
             showAlertBluetooth()
         }
 
-        stepTwoRecyclerView.apply {
+        binding.stepTwoRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = songMeterAdapter
         }
 
-        stepFourRecyclerView.apply {
+        binding.stepFourRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = songMeterAdapter
         }
@@ -105,7 +114,7 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
         observeSetSite()
     }
 
-    private fun setStepButton() {
+    private fun setStepButton() = binding.apply {
         stepOneButton.setOnClickListener {
             showStep(2)
             songMeterViewModel.scanBle(true)
@@ -147,6 +156,7 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
             selectedAdvertisement = null
             backToBeginning()
         }
+        Unit
     }
 
     private fun observeSetSite() {
@@ -198,7 +208,7 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
         showStep(1)
     }
 
-    private fun showStep(step: Int) {
+    private fun showStep(step: Int) = binding.apply {
         when (step) {
             1 -> {
                 currentStep = 1
@@ -250,6 +260,7 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
                 stepFourLoading.visibility = View.VISIBLE
             }
         }
+        Unit
     }
 
     private fun setupTopBar() {
@@ -269,21 +280,21 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
                         if (it.data != null) {
                             songMeterAdapter.items = it.data
                             if (currentStep == 2) {
-                                stepTwoLoading.visibility = View.GONE
+                                binding.stepTwoLoading.visibility = View.GONE
                             } else if (currentStep == 4) {
-                                stepFourLoading.visibility = View.GONE
+                                binding.stepFourLoading.visibility = View.GONE
                             }
                             if (currentStep == 3) {
                                 it.data.find { detect -> detect.serialName == selectedAdvertisement?.serialName }
                                     ?.let { filtered ->
                                         if (filtered.isReadyToPair) {
-                                            stepThreeSyncButton.isEnabled = true
+                                            binding.stepThreeSyncButton.isEnabled = true
                                         }
                                     }
                             }
                             if (currentStep == 4) {
                                 it.data.find { detect -> detect.prefixes == setPrefixes }?.let {
-                                    stepFourYesButton.isEnabled = true
+                                    binding.stepFourYesButton.isEnabled = true
                                 }
                             }
                         }
@@ -332,9 +343,9 @@ class SongMeterDetectFragment : Fragment(), (Advertisement) -> Unit {
 
     override fun invoke(ads: Advertisement) {
         selectedAdvertisement = ads
-        stepThreePrefixesTextView.text = ads.prefixes
-        stepThreeSerialNumberTextView.text = ads.serialName
-        stepTwoYesButton.isEnabled = true
+        binding.stepThreePrefixesTextView.text = ads.prefixes
+        binding.stepThreeSerialNumberTextView.text = ads.serialName
+        binding.stepTwoYesButton.isEnabled = true
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/viewmodel/SongMeterViewModel.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/songmeter/viewmodel/SongMeterViewModel.kt
@@ -62,16 +62,12 @@ class SongMeterViewModel(
         val preferences = Preferences.getInstance(context)
         val projectId = preferences.getInt(Preferences.SELECTED_PROJECT)
         siteLiveData =
-            Transformations.map(
-                songMeterRepository.getAllResultsAsyncWithinProject(projectId)
-                    .asLiveData()
-            ) { it }
+            songMeterRepository.getAllResultsAsyncWithinProject(projectId)
+                .asLiveData().map { it }
         siteLiveData.observeForever(siteObserve)
 
-        deploymentLiveData = Transformations.map(
-            songMeterRepository.getAllDeploymentResultsAsyncWithinProject(projectId)
-                .asLiveData()
-        ) { it }
+        deploymentLiveData = songMeterRepository.getAllDeploymentResultsAsyncWithinProject(projectId)
+            .asLiveData().map { it }
         deploymentLiveData.observeForever(deploymentObserve)
 
         downloadStreamsWorkInfoLiveData = DownloadStreamsWorker.workInfos(context)

--- a/app/src/main/java/org/rfcx/companion/view/deployment/sync/NewSyncFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/deployment/sync/NewSyncFragment.kt
@@ -14,8 +14,8 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.fragment_new_sync.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentNewSyncBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.Analytics
 import org.rfcx.companion.view.deployment.AudioMothDeploymentProtocol
@@ -29,6 +29,9 @@ class NewSyncFragment : Fragment() {
     private val analytics by lazy { context?.let { Analytics(it) } }
     private var step: Int? = null
 
+    private var _binding: FragmentNewSyncBinding? = null
+    private val binding get() = _binding!!
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         audioMothDeploymentProtocol = (context as AudioMothDeploymentProtocol)
@@ -40,7 +43,13 @@ class NewSyncFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         arguments?.let { step = it.getInt(STEP) }
-        return inflater.inflate(R.layout.fragment_new_sync, container, false)
+        _binding = FragmentNewSyncBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onDetach() {
@@ -83,54 +92,54 @@ class NewSyncFragment : Fragment() {
 
         setLabelColor(view)
 
-        beginSyncButton.setOnClickListener {
+        binding.beginSyncButton.setOnClickListener {
             analytics?.trackPlayToneEvent()
             audioMothDeploymentProtocol?.playTone(100000)
             setStep(2)
         }
-        notHearButton.setOnClickListener {
+        binding.notHearButton.setOnClickListener {
             analytics?.trackRetryPlayToneEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             setStep(1)
         }
-        hearButton.setOnClickListener {
+        binding.hearButton.setOnClickListener {
             setStep(3)
         }
-        notSwitchButton.setOnClickListener {
+        binding.notSwitchButton.setOnClickListener {
             analytics?.trackRetryPlayToneEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             setStep(1)
         }
-        switchButton.setOnClickListener {
+        binding.switchButton.setOnClickListener {
             setStep(4)
         }
-        notSeeLightsAudiomothButton.setOnClickListener {
+        binding.notSeeLightsAudiomothButton.setOnClickListener {
             analytics?.trackRetryPlayToneEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             setStep(1)
         }
-        seeLightsAudiomothButton.setOnClickListener {
+        binding.seeLightsAudiomothButton.setOnClickListener {
             analytics?.trackPlayToneCompletedEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             setStep(5)
         }
-        syncAudioMothButton.setOnClickListener {
-            movePhoneNearTextView.text = getString(R.string.keep_phone_near)
-            syncAudioMothButton.isEnabled = false
-            syncAudioMothButton.text = getString(R.string.sync_in_progress)
-            syncAudioMothFinishButton.visibility = View.GONE
+        binding.syncAudioMothButton.setOnClickListener {
+            binding.movePhoneNearTextView.text = getString(R.string.keep_phone_near)
+            binding.syncAudioMothButton.isEnabled = false
+            binding.syncAudioMothButton.text = getString(R.string.sync_in_progress)
+            binding.syncAudioMothFinishButton.visibility = View.GONE
             analytics?.trackPlaySyncToneEvent()
             audioMothDeploymentProtocol?.playSyncSound()
         }
-        syncAudioMothFinishButton.setOnClickListener {
+        binding.syncAudioMothFinishButton.setOnClickListener {
             setStep(6)
         }
-        notConfirmLightButton.setOnClickListener {
+        binding.notConfirmLightButton.setOnClickListener {
             analytics?.trackRetryPlayToneEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             setStep(1)
         }
-        confirmLightButton.setOnClickListener {
+        binding.confirmLightButton.setOnClickListener {
             analytics?.trackPlaySyncToneCompletedEvent()
             audioMothDeploymentProtocol?.stopPlaySound()
             showComplete()
@@ -139,9 +148,9 @@ class NewSyncFragment : Fragment() {
 
     fun showRepeatSync() {
         context?.let {
-            syncAudioMothButton.text = getString(R.string.repeat_sound)
-            syncAudioMothButton.isEnabled = true
-            syncAudioMothFinishButton.visibility = View.VISIBLE
+            _binding?.syncAudioMothButton?.text = getString(R.string.repeat_sound)
+            _binding?.syncAudioMothButton?.isEnabled = true
+            _binding?.syncAudioMothFinishButton?.visibility = View.VISIBLE
         }
     }
 
@@ -176,7 +185,7 @@ class NewSyncFragment : Fragment() {
             spannableString.setSpan(red, 32, 41, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             spannableString.setSpan(green, 44, 58, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-        lightsAudiomothTextView.text = spannableString
+        binding.lightsAudiomothTextView.text = spannableString
 
         val confirmLight = SpannableString(getString(R.string.six))
         if (isPortuguese) {
@@ -189,10 +198,10 @@ class NewSyncFragment : Fragment() {
             confirmLight.setSpan(red, 20, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             confirmLight.setSpan(UnderlineSpan(), 33, 36, 0)
         }
-        stepSixTextView.text = confirmLight
+        binding.stepSixTextView.text = confirmLight
     }
 
-    private fun setStep(step: Int) {
+    private fun setStep(step: Int) = binding.apply {
         when (step) {
             1 -> {
                 setHardwareSwitchToOffLayout.visibility = View.VISIBLE
@@ -273,6 +282,7 @@ class NewSyncFragment : Fragment() {
                 confirmLightLayout.visibility = View.VISIBLE
             }
         }
+        Unit
     }
 
     companion object {

--- a/app/src/main/java/org/rfcx/companion/view/detail/DeploymentDetailActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/DeploymentDetailActivity.kt
@@ -9,8 +9,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -18,11 +18,10 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.android.synthetic.main.activity_deployment_detail.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.BuildConfig
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityDeploymentDetailBinding
 import org.rfcx.companion.entity.*
 import org.rfcx.companion.entity.guardian.Deployment
 import org.rfcx.companion.localdb.DatabaseCallback
@@ -67,6 +66,8 @@ class DeploymentDetailActivity :
 
     private var toAddImage = false
 
+    private lateinit var binding: ActivityDeploymentDetailBinding
+
     private lateinit var deploymentLiveData: LiveData<List<Deployment>>
     private val deploymentObserve = Observer<List<Deployment>> {
         deployment?.let {
@@ -82,19 +83,18 @@ class DeploymentDetailActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_deployment_detail)
+        binding = ActivityDeploymentDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setViewModel()
 
-        deploymentLiveData = Transformations.map(
-            viewModel.getAllDeploymentLocateResultsAsync().asLiveData()
-        ) { it }
+        deploymentLiveData = viewModel.getAllDeploymentLocateResultsAsync().asLiveData().map { it }
         deploymentLiveData.observeForever(deploymentObserve)
 
         val preferences = Preferences.getInstance(this)
         val projectId = preferences.getInt(Preferences.SELECTED_PROJECT)
         val project = viewModel.getProjectById(projectId)
 
-        deleteButton.visibility =
+        binding.deleteButton.visibility =
             if (project?.permissions == Permissions.ADMIN.value) View.VISIBLE else View.GONE
 
         val mapFragment = supportFragmentManager.findFragmentById(R.id.mapView) as SupportMapFragment
@@ -116,11 +116,11 @@ class DeploymentDetailActivity :
         setupClickListener()
 
         // setup onclick
-        deleteButton.setOnClickListener {
+        binding.deleteButton.setOnClickListener {
             confirmationDialog()
         }
 
-        editButton.setOnClickListener {
+        binding.editButton.setOnClickListener {
             deployment?.let {
                 val stream = deployment?.stream
                 stream?.let { st ->
@@ -257,10 +257,10 @@ class DeploymentDetailActivity :
         observeDeploymentImage(deployment.id, deployment.device ?: Device.AUDIOMOTH.value)
         val location = deployment.stream
         location?.let { locate ->
-            latitudeValue.text = locate.latitude.latitudeCoordinates(this)
-            longitudeValue.text = locate.longitude.longitudeCoordinates(this)
-            altitudeValue.text = locate.altitude.setFormatLabel()
-            deploymentIdTextView.text = deployment.deploymentKey
+            binding.latitudeValue.text = locate.latitude.latitudeCoordinates(this)
+            binding.longitudeValue.text = locate.longitude.longitudeCoordinates(this)
+            binding.altitudeValue.text = locate.altitude.setFormatLabel()
+            binding.deploymentIdTextView.text = deployment.deploymentKey
         }
     }
 
@@ -272,7 +272,7 @@ class DeploymentDetailActivity :
 
     private fun observeDeploymentImage(deploymentId: Int, device: String) {
         deployImageLiveData =
-            Transformations.map(viewModel.getAllResultsAsync(deploymentId, device).asLiveData()) {
+            viewModel.getAllResultsAsync(deploymentId, device).asLiveData().map {
                 it
             }
         deployImageLiveData.observeForever(deploymentImageObserve)
@@ -287,7 +287,7 @@ class DeploymentDetailActivity :
     }
 
     private fun setupImageRecycler() {
-        deploymentImageRecycler.apply {
+        binding.deploymentImageRecycler.apply {
             adapter = deploymentImageAdapter
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             setHasFixedSize(true)
@@ -308,7 +308,7 @@ class DeploymentDetailActivity :
         map?.animateCamera(CameraUpdateFactory.zoomTo(DEFAULT_ZOOM))
     }
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/detail/DeploymentImageAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/DeploymentImageAdapter.kt
@@ -10,9 +10,9 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_image.view.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.BaseListItem
+import org.rfcx.companion.databinding.ItemImageBinding
 import org.rfcx.companion.entity.SyncState
 import org.rfcx.companion.extension.setDeploymentImage
 import org.rfcx.companion.util.getIdToken
@@ -141,9 +141,9 @@ class DeploymentImageAdapter :
         context = parent.context
         return when (viewType) {
             VIEW_TYPE_IMAGE -> {
-                val view = LayoutInflater.from(parent.context)
-                    .inflate(R.layout.item_image, parent, false)
-                ImageAdapterViewHolder(view, onImageAdapterClickListener)
+                val binding = ItemImageBinding
+                    .inflate(LayoutInflater.from(parent.context), parent, false)
+                ImageAdapterViewHolder(binding, onImageAdapterClickListener)
             }
             VIEW_TYPE_ADD_IMAGE -> {
                 val view = LayoutInflater.from(parent.context)
@@ -155,13 +155,13 @@ class DeploymentImageAdapter :
     }
 
     inner class ImageAdapterViewHolder(
-        itemView: View,
+        private val binding: ItemImageBinding,
         private val onImageAdapterClickListener: OnImageAdapterClickListener?
-    ) : RecyclerView.ViewHolder(itemView) {
-        private val imageView = itemView.image
-        private val deleteButton = itemView.deleteImageButton
-        private val syncImageView = itemView.syncImage
-        private val progress = itemView.progressBarOfImageView
+    ) : RecyclerView.ViewHolder(binding.root) {
+        private val imageView = binding.image
+        private val deleteButton = binding.deleteImageButton
+        private val syncImageView = binding.syncImage
+        private val progress = binding.progressBarOfImageView
 
         fun bind(item: DeploymentImageView, canDelete: Boolean) {
             syncImageView.visibility = View.VISIBLE

--- a/app/src/main/java/org/rfcx/companion/view/detail/DisplayImageActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/DisplayImageActivity.kt
@@ -5,25 +5,26 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
-import kotlinx.android.synthetic.main.activity_display_image.*
-import kotlinx.android.synthetic.main.toolbar_default.*
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ActivityDisplayImageBinding
 
 class DisplayImageActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityDisplayImageBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_display_image)
+        binding = ActivityDisplayImageBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         val paths = intent.extras?.getStringArray(PATH_IMAGE) ?: arrayOf()
         val labels = intent.extras?.getStringArray(LABEL_IMAGE) ?: arrayOf()
         setupToolbar()
 
         val adapter = DisplayImageAdapter(paths.toList(), this)
-        imageViewPager.orientation = ViewPager2.ORIENTATION_HORIZONTAL
-        imageViewPager.adapter = adapter
+        binding.imageViewPager.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+        binding.imageViewPager.adapter = adapter
 
-        imageViewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+        binding.imageViewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 setupToolbarTitle(labels[position])
@@ -31,7 +32,7 @@ class DisplayImageActivity : AppCompatActivity() {
         })
     }
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/detail/DisplayImageAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/DisplayImageAdapter.kt
@@ -2,11 +2,9 @@ package org.rfcx.companion.view.detail
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_display_image.view.*
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemDisplayImageBinding
 import org.rfcx.companion.extension.setDeploymentImage
 import org.rfcx.companion.util.getIdToken
 
@@ -14,8 +12,8 @@ class DisplayImageAdapter(private val imageList: List<String>, private val conte
     RecyclerView.Adapter<DisplayImageAdapter.DisplayImageViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DisplayImageViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_display_image, parent, false)
-        return DisplayImageViewHolder(view)
+        val binding = ItemDisplayImageBinding.inflate(LayoutInflater.from(context), parent, false)
+        return DisplayImageViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: DisplayImageViewHolder, position: Int) {
@@ -24,9 +22,9 @@ class DisplayImageAdapter(private val imageList: List<String>, private val conte
 
     override fun getItemCount(): Int = imageList.size
 
-    inner class DisplayImageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val imageView = itemView.displayImage
-        private val progressBar = itemView.progressBarOfImageView
+    inner class DisplayImageViewHolder(binding: ItemDisplayImageBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val imageView = binding.displayImage
+        private val progressBar = binding.progressBarOfImageView
 
         fun bind(item: String) {
             val token = context.getIdToken()

--- a/app/src/main/java/org/rfcx/companion/view/detail/EditLocationActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/EditLocationActivity.kt
@@ -8,10 +8,9 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.activity_edit_location.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityEditLocationBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.entity.Stream
@@ -35,15 +34,17 @@ class EditLocationActivity : AppCompatActivity(), MapPickerProtocol, EditLocatio
     private var deploymentId: Int? = null
     private var selectedProject: Int? = null
     private var device: String? = null
+    private lateinit var binding: ActivityEditLocationBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_edit_location)
+        binding = ActivityEditLocationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         setViewModel()
         setupToolbar()
         initIntent()
-        toolbarLayout.visibility = View.VISIBLE
+        binding.toolbarLayout.root.visibility = View.VISIBLE
 
         startFragment(
             MapPickerFragment.newInstance(
@@ -103,11 +104,11 @@ class EditLocationActivity : AppCompatActivity(), MapPickerProtocol, EditLocatio
     }
 
     override fun showAppbar() {
-        toolbarLayout.visibility = View.VISIBLE
+        binding.toolbarLayout.root.visibility = View.VISIBLE
     }
 
     override fun hideAppbar() {
-        toolbarLayout.visibility = View.GONE
+        binding.toolbarLayout.root.visibility = View.GONE
     }
 
     override fun onSelectedLocation(
@@ -116,7 +117,7 @@ class EditLocationActivity : AppCompatActivity(), MapPickerProtocol, EditLocatio
         siteId: Int,
         name: String
     ) {
-        toolbarLayout.visibility = View.VISIBLE
+        binding.toolbarLayout.root.visibility = View.VISIBLE
         setLatLng(latitude, longitude, altitude)
         startFragment(EditLocationFragment.newInstance(latitude, longitude, altitude, siteId))
     }
@@ -127,7 +128,7 @@ class EditLocationActivity : AppCompatActivity(), MapPickerProtocol, EditLocatio
         altitude: Double,
         streamId: Int
     ) {
-        toolbarLayout.visibility = View.VISIBLE
+        binding.toolbarLayout.root.visibility = View.VISIBLE
         setLatLng(latitude, longitude, altitude)
         startFragment(MapPickerFragment.newInstance(latitude, longitude, altitude, streamId))
     }
@@ -171,12 +172,12 @@ class EditLocationActivity : AppCompatActivity(), MapPickerProtocol, EditLocatio
 
     private fun startFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-            .replace(editLocationContainer.id, fragment)
+            .replace(binding.editLocationContainer.id, fragment)
             .commit()
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/detail/EditLocationFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/EditLocationFragment.kt
@@ -23,12 +23,8 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import io.realm.Realm
-import kotlinx.android.synthetic.main.fragment_edit_location.*
-import kotlinx.android.synthetic.main.fragment_edit_location.altitudeEditText
-import kotlinx.android.synthetic.main.fragment_edit_location.locationGroupValueTextView
-import kotlinx.android.synthetic.main.fragment_edit_location.locationNameEditText
-import kotlinx.android.synthetic.main.fragment_edit_location.locationValueTextView
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentEditLocationBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.localdb.StreamDb
 import org.rfcx.companion.util.Analytics
@@ -50,6 +46,9 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
 
     private var editLocationActivityListener: EditLocationActivityListener? = null
 
+    private var _binding: FragmentEditLocationBinding? = null
+    private val binding get() = _binding!!
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         editLocationActivityListener = context as EditLocationActivityListener
@@ -66,7 +65,13 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_edit_location, container, false)
+        _binding = FragmentEditLocationBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -81,22 +86,22 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
 
         val stream = editLocationActivityListener?.getStream(streamId)
         val streams = streamDb.getStreams().map { it.name }
-        locationNameEditText.setText(stream?.name ?: getString(R.string.none))
-        altitudeEditText.setText(altitude.toString())
-        locationValueTextView.text = context?.let { convertLatLngLabel(it, latitude, longitude) }
+        binding.locationNameEditText.setText(stream?.name ?: getString(R.string.none))
+        binding.altitudeEditText.setText(altitude.toString())
+        binding.locationValueTextView.text = context?.let { convertLatLngLabel(it, latitude, longitude) }
 
-        changeButton.setOnClickListener {
+        binding.changeButton.setOnClickListener {
             openMapPickerPage()
             analytics?.trackChangeLocationEvent(Screen.EDIT_LOCATION.id)
         }
 
-        viewMapBox.setOnClickListener {
+        binding.viewMapBox.setOnClickListener {
             openMapPickerPage()
             analytics?.trackChangeLocationEvent(Screen.EDIT_LOCATION.id)
         }
 
-        saveButton.setOnClickListener {
-            if (locationNameEditText.text.isNullOrBlank()) {
+        binding.saveButton.setOnClickListener {
+            if (binding.locationNameEditText.text.isNullOrBlank()) {
                 Toast.makeText(
                     context,
                     getString(R.string.please_fill_information),
@@ -104,23 +109,23 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
                 ).show()
             } else {
                 analytics?.trackSaveLocationEvent(Screen.EDIT_LOCATION.id)
-                altitude = altitudeEditText.text.toString().toDouble()
-                editLocationActivityListener?.updateDeploymentDetail(locationNameEditText.text.toString(), altitude)
+                altitude = binding.altitudeEditText.text.toString().toDouble()
+                editLocationActivityListener?.updateDeploymentDetail(binding.locationNameEditText.text.toString(), altitude)
             }
         }
 
-        editGroupButton.setOnClickListener {
+        binding.editGroupButton.setOnClickListener {
             analytics?.trackChangeLocationGroupEvent(Screen.EDIT_LOCATION.id)
             editLocationActivityListener?.startLocationGroupPage()
         }
 
-        locationNameEditText.addTextChangedListener(object : TextWatcher {
+        binding.locationNameEditText.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {
-                val name = locationNameEditText.text.toString()
+                val name = binding.locationNameEditText.text.toString()
                 if (streams.contains(name) && (stream?.name ?: getString(R.string.none)) != name) {
-                    locationNameTextInput.error = getString(R.string.site_name_exists)
+                    binding.locationNameTextInput.error = getString(R.string.site_name_exists)
                 } else {
-                    locationNameTextInput.error = null
+                    binding.locationNameTextInput.error = null
                 }
             }
 
@@ -134,7 +139,7 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
         editLocationActivityListener?.startMapPickerPage(
             latitude,
             longitude,
-            altitudeEditText.text.toString().toDouble(),
+            binding.altitudeEditText.text.toString().toDouble(),
             streamId
         )
     }
@@ -145,11 +150,9 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
         view?.getWindowVisibleDisplayFrame(r)
         val keypadHeight: Int = screenHeight - r.bottom
         if (keypadHeight > screenHeight * 0.15) {
-            saveButton.visibility = View.GONE
+            _binding?.saveButton?.visibility = View.GONE
         } else {
-            if (saveButton != null) {
-                saveButton.visibility = View.VISIBLE
-            }
+            _binding?.saveButton?.visibility = View.VISIBLE
         }
     }
 
@@ -162,7 +165,7 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
                 }
                 false
             }
-        locationNameEditText.setOnEditorActionListener(editorActionListener)
+        binding.locationNameEditText.setOnEditorActionListener(editorActionListener)
     }
 
     private fun initIntent() {
@@ -217,7 +220,7 @@ class EditLocationFragment : Fragment(), OnMapReadyCallback {
     override fun onResume() {
         super.onResume()
         editLocationActivityListener?.let {
-            locationGroupValueTextView.text = it.getStream(streamId).project?.name
+            binding.locationGroupValueTextView.text = it.getStream(streamId).project?.name
         }
     }
 

--- a/app/src/main/java/org/rfcx/companion/view/detail/image/AddImageActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/detail/image/AddImageActivity.kt
@@ -11,10 +11,10 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.android.synthetic.main.fragment_deploy.*
 import org.rfcx.companion.BuildConfig
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentDeployBinding
 import org.rfcx.companion.entity.Device
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
@@ -55,6 +55,8 @@ class AddImageActivity : AppCompatActivity(), ImageClickListener, GuidelineButto
     private var deploymentId: Int? = -1
     private var newImages: List<Image>? = null
     private var maxImages = 10
+
+    private lateinit var binding: FragmentDeployBinding
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
@@ -123,7 +125,8 @@ class AddImageActivity : AppCompatActivity(), ImageClickListener, GuidelineButto
             }
         }
 
-        setContentView(R.layout.fragment_deploy)
+        binding = FragmentDeployBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setViewModel()
         initIntent()
         getPlaceHolder()
@@ -131,7 +134,7 @@ class AddImageActivity : AppCompatActivity(), ImageClickListener, GuidelineButto
         setupImageRecycler()
         updatePhotoTakenNumber()
 
-        finishButton.setOnClickListener {
+        binding.finishButton.setOnClickListener {
             val missing = getImageAdapter().getMissingImages()
             if (missing.isEmpty()) {
                 handleNextStep()
@@ -161,7 +164,7 @@ class AddImageActivity : AppCompatActivity(), ImageClickListener, GuidelineButto
     }
 
     private fun setupImageRecycler() {
-        attachImageRecycler.apply {
+        binding.attachImageRecycler.apply {
             adapter = getImageAdapter()
             layoutManager = GridLayoutManager(context, 3)
         }
@@ -202,9 +205,9 @@ class AddImageActivity : AppCompatActivity(), ImageClickListener, GuidelineButto
     }
 
     private fun updatePhotoTakenNumber() {
-        photoTakenTextView.visibility = View.VISIBLE
+        binding.photoTakenTextView.visibility = View.VISIBLE
         val number = getImageAdapter().getExistingImages().size
-        photoTakenTextView.text =
+        binding.photoTakenTextView.text =
             getString(R.string.photo_taken, number, getImageAdapter().itemCount)
     }
 

--- a/app/src/main/java/org/rfcx/companion/view/dialog/CompleteFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/dialog/CompleteFragment.kt
@@ -9,11 +9,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import kotlinx.android.synthetic.main.fragment_complete.*
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentCompleteBinding
 
 class CompleteFragment : DialogFragment() {
     private var completeListener: CompleteListener? = null
+    private var _binding: FragmentCompleteBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -25,14 +26,20 @@ class CompleteFragment : DialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_complete, container, false)
+        _binding = FragmentCompleteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
-        animationView.addAnimatorListener(object : Animator.AnimatorListener {
+        binding.animationView.addAnimatorListener(object : Animator.AnimatorListener {
             override fun onAnimationRepeat(animation: Animator) {}
 
             override fun onAnimationEnd(animation: Animator) {

--- a/app/src/main/java/org/rfcx/companion/view/dialog/PhotoGuidelineDialogFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/dialog/PhotoGuidelineDialogFragment.kt
@@ -5,14 +5,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import kotlinx.android.synthetic.main.fragment_photo_guideline.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentPhotoGuidelineBinding
 
 class PhotoGuidelineDialogFragment(private val guidelineButtonClickListener: GuidelineButtonClickListener) :
     DialogFragment() {
 
     private var guidelineText = ""
     private var photoId = ""
+    private var _binding: FragmentPhotoGuidelineBinding? = null
+    private val binding get() = _binding!!
 
     override fun onStart() {
         super.onStart()
@@ -31,7 +33,13 @@ class PhotoGuidelineDialogFragment(private val guidelineButtonClickListener: Gui
     ): View? {
         guidelineText = arguments?.getString(ARG_TEXT) ?: ""
         photoId = arguments?.getString(ARG_PHOTO) ?: ""
-        return inflater.inflate(R.layout.fragment_photo_guideline, container, false)
+        _binding = FragmentPhotoGuidelineBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -40,12 +48,12 @@ class PhotoGuidelineDialogFragment(private val guidelineButtonClickListener: Gui
         setExamplePhoto(photoId)
         setExampleText(guidelineText)
 
-        takePhotoButton.setOnClickListener {
+        binding.takePhotoButton.setOnClickListener {
             dismiss()
             guidelineButtonClickListener.onTakePhotoClick()
         }
 
-        choosePhotoButton.setOnClickListener {
+        binding.choosePhotoButton.setOnClickListener {
             dismiss()
             guidelineButtonClickListener.onChoosePhotoClick()
         }
@@ -57,11 +65,11 @@ class PhotoGuidelineDialogFragment(private val guidelineButtonClickListener: Gui
         val id = resources.getIdentifier(photoId, "drawable", requireContext().packageName)
         if (id == 0) return
 
-        guidelineImage.setImageResource(resources.getIdentifier(photoId, "drawable", requireContext().packageName))
+        binding.guidelineImage.setImageResource(resources.getIdentifier(photoId, "drawable", requireContext().packageName))
     }
 
     private fun setExampleText(text: String) {
-        guidelineTextView.text = text.ifEmpty { getString(R.string.take_other) }
+        binding.guidelineTextView.text = text.ifEmpty { getString(R.string.take_other) }
     }
 
     companion object {

--- a/app/src/main/java/org/rfcx/companion/view/dialog/SiteLoadingDialogFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/dialog/SiteLoadingDialogFragment.kt
@@ -7,26 +7,34 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import kotlinx.android.synthetic.main.fragment_sites_loading.*
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentSitesLoadingBinding
 
 class SiteLoadingDialogFragment(private val text: String) : DialogFragment() {
+
+    private var _binding: FragmentSitesLoadingBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_sites_loading, container, false)
+        _binding = FragmentSitesLoadingBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
-        siteLoadingText.text = this.text
+        binding.siteLoadingText.text = this.text
 
-        siteLoadingButton.setOnClickListener {
+        binding.siteLoadingButton.setOnClickListener {
             dismissDialog()
         }
     }

--- a/app/src/main/java/org/rfcx/companion/view/map/MapFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/map/MapFragment.kt
@@ -44,10 +44,6 @@ import com.google.gson.JsonSyntaxException
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterManager
 import io.realm.Realm
-import kotlinx.android.synthetic.main.fragment_map.*
-import kotlinx.android.synthetic.main.layout_deployment_window_info.view.*
-import kotlinx.android.synthetic.main.layout_map_window_info.view.*
-import kotlinx.android.synthetic.main.layout_search_view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -56,6 +52,7 @@ import org.rfcx.companion.MainActivityListener
 import org.rfcx.companion.MainViewModel
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentMapBinding
 import org.rfcx.companion.entity.*
 import org.rfcx.companion.localdb.TrackingDb
 import org.rfcx.companion.repo.api.CoreApiHelper
@@ -118,6 +115,9 @@ class MapFragment :
 
     private val handler: Handler = Handler()
 
+    private var _binding: FragmentMapBinding? = null
+    private val binding get() = _binding!!
+
     private var currentAnimator: Animator? = null
     private var polyline: Polyline? = null
     private var currentMarkId = ""
@@ -162,7 +162,7 @@ class MapFragment :
 
             Status.SUCCESS -> {
 //                mainViewModel.updateProjectBounds()
-                projectSwipeRefreshView.isRefreshing = false
+                _binding?.projectSwipeRefreshView?.isRefreshing = false
 
                 this.projects = mainViewModel.getProjectsFromLocal()
                 locationGroupAdapter.items = listOf()
@@ -174,7 +174,7 @@ class MapFragment :
 
             Status.ERROR -> {
                 combinedData()
-                projectSwipeRefreshView.isRefreshing = false
+                _binding?.projectSwipeRefreshView?.isRefreshing = false
                 showToast(it.message ?: getString(R.string.error_has_occurred))
             }
         }
@@ -381,7 +381,13 @@ class MapFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_map, container, false)
+        _binding = FragmentMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -404,13 +410,13 @@ class MapFragment :
         }
 
         context?.let { setTextTrackingButton(LocationTrackingManager.isTrackingOn(it)) }
-        projectNameTextView.text =
+        binding.projectNameTextView.text =
             if (listener?.getProjectName() != getString(R.string.none)) listener?.getProjectName() else getString(
                 R.string.projects
             )
-        searchLayoutSearchEditText.hint = getString(R.string.site_name_hint)
+        binding.searchView.searchLayoutSearchEditText.hint = getString(R.string.site_name_hint)
 
-        currentLocationButton.setOnClickListener {
+        binding.currentLocationButton.setOnClickListener {
             if (locationPermissions?.allowed() == true) {
                 map.isMyLocationEnabled = true
                 fusedLocationClient()
@@ -420,25 +426,25 @@ class MapFragment :
             }
         }
 
-        zoomOutButton.setOnClickListener {
+        binding.zoomOutButton.setOnClickListener {
             map.animateCamera(CameraUpdateFactory.zoomOut())
         }
 
-        zoomInButton.setOnClickListener {
+        binding.zoomInButton.setOnClickListener {
             map.animateCamera(CameraUpdateFactory.zoomIn())
         }
 
-        projectNameTextView.setOnClickListener {
+        binding.projectNameTextView.setOnClickListener {
             setOnClickProjectName()
         }
 
-        unSyncedDpNumber.setOnClickListener {
+        binding.unSyncedDpNumber.setOnClickListener {
             if (unsyncedDeploymentCount != 0) {
                 UnsyncedWorksActivity.startActivity(requireContext())
             }
         }
 
-        projectSwipeRefreshView.apply {
+        binding.projectSwipeRefreshView.apply {
             setOnRefreshListener {
                 mainViewModel.fetchProjects()
                 isRefreshing = true
@@ -446,7 +452,7 @@ class MapFragment :
             setColorSchemeResources(R.color.colorPrimary)
         }
 
-        siteSwipeRefreshView.apply {
+        binding.siteSwipeRefreshView.apply {
             setOnRefreshListener {
                 mainViewModel.retrieveLocations()
                 isRefreshing = false
@@ -454,16 +460,16 @@ class MapFragment :
             setColorSchemeResources(R.color.colorPrimary)
         }
 
-        iconOpenProjectList.setOnClickListener {
+        binding.iconOpenProjectList.setOnClickListener {
             setOnClickProjectName()
         }
 
-        siteRecyclerView.apply {
+        binding.siteRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = siteAdapter
         }
 
-        projectRecyclerView.apply {
+        binding.projectRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = locationGroupAdapter
             locationGroupAdapter.screen = Screen.MAP.id
@@ -484,61 +490,61 @@ class MapFragment :
 
     private fun setOnClickProjectName() {
         val state = listener?.getBottomSheetState() ?: 0
-        if (state == BottomSheetBehavior.STATE_EXPANDED && searchLayout.visibility != View.VISIBLE) {
+        if (state == BottomSheetBehavior.STATE_EXPANDED && binding.searchView.searchLayout.visibility != View.VISIBLE) {
             listener?.hideBottomSheet()
         }
 
-        if (projectRecyclerView.visibility == View.VISIBLE) {
-            projectRecyclerView.visibility = View.GONE
-            projectSwipeRefreshView.visibility = View.GONE
-            searchButton.visibility = View.VISIBLE
-            trackingLayout.visibility = View.VISIBLE
+        if (binding.projectRecyclerView.visibility == View.VISIBLE) {
+            binding.projectRecyclerView.visibility = View.GONE
+            binding.projectSwipeRefreshView.visibility = View.GONE
+            binding.searchButton.visibility = View.VISIBLE
+            binding.trackingLayout.visibility = View.VISIBLE
             showButtonOnMap()
             listener?.showBottomAppBar()
         } else {
-            projectRecyclerView.visibility = View.VISIBLE
-            projectSwipeRefreshView.visibility = View.VISIBLE
+            binding.projectRecyclerView.visibility = View.VISIBLE
+            binding.projectSwipeRefreshView.visibility = View.VISIBLE
             showSearchBar(false)
-            searchButton.visibility = View.GONE
-            trackingLayout.visibility = View.GONE
+            binding.searchButton.visibility = View.GONE
+            binding.trackingLayout.visibility = View.GONE
             hideButtonOnMap()
             listener?.hideBottomAppBar()
         }
 
-        if (siteRecyclerView.visibility == View.VISIBLE) {
-            searchLayout.visibility = View.GONE
+        if (binding.siteRecyclerView.visibility == View.VISIBLE) {
+            binding.searchView.searchLayout.visibility = View.GONE
             hideLabel()
-            searchLayoutSearchEditText.text = null
+            binding.searchView.searchLayoutSearchEditText.text = null
         }
     }
 
     private fun showLabel(isNotFound: Boolean) {
-        if (siteRecyclerView.visibility == View.VISIBLE && projectRecyclerView.visibility != View.VISIBLE) {
-            showLabelLayout.visibility = View.VISIBLE
-            notHaveSiteTextView.visibility = if (isNotFound) View.GONE else View.VISIBLE
-            notHaveResultTextView.visibility = if (isNotFound) View.VISIBLE else View.GONE
+        if (binding.siteRecyclerView.visibility == View.VISIBLE && binding.projectRecyclerView.visibility != View.VISIBLE) {
+            binding.showLabelLayout.visibility = View.VISIBLE
+            binding.notHaveSiteTextView.visibility = if (isNotFound) View.GONE else View.VISIBLE
+            binding.notHaveResultTextView.visibility = if (isNotFound) View.VISIBLE else View.GONE
         }
     }
 
     private fun hideLabel() {
-        showLabelLayout.visibility = View.GONE
+        binding.showLabelLayout.visibility = View.GONE
     }
 
     private fun setupSearch() {
-        searchButton.setOnClickListener {
+        binding.searchButton.setOnClickListener {
             showSearchBar(true)
         }
 
-        searchViewActionRightButton.setOnClickListener {
-            if (searchLayoutSearchEditText.text.isNullOrBlank()) {
+        binding.searchView.searchViewActionRightButton.setOnClickListener {
+            if (binding.searchView.searchLayoutSearchEditText.text.isNullOrBlank()) {
                 showSearchBar(false)
                 it.hideKeyboard()
             } else {
-                searchLayoutSearchEditText.text = null
+                binding.searchView.searchLayoutSearchEditText.text = null
             }
         }
 
-        searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
+        binding.searchView.searchLayoutSearchEditText.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {
                 context?.let {
                     val text = s.toString().lowercase(Locale.getDefault())
@@ -557,7 +563,7 @@ class MapFragment :
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
         })
 
-        trackingLayout.setOnClickListener {
+        binding.trackingLayout.setOnClickListener {
             if (locationPermissions?.allowed() == false) {
                 locationPermissions?.check { /* do nothing */ }
             } else {
@@ -590,25 +596,25 @@ class MapFragment :
     }
 
     fun showSearchBar(show: Boolean) {
-        searchLayout.visibility = if (show) View.VISIBLE else View.INVISIBLE
-        siteRecyclerView.visibility = if (show) View.VISIBLE else View.INVISIBLE
-        siteSwipeRefreshView.visibility = if (show) View.VISIBLE else View.INVISIBLE
-        searchViewActionRightButton.visibility = if (show) View.VISIBLE else View.INVISIBLE
-        searchButton.visibility = if (show) View.GONE else View.VISIBLE
-        trackingLayout.visibility = if (show) View.GONE else View.VISIBLE
+        binding.searchView.searchLayout.visibility = if (show) View.VISIBLE else View.INVISIBLE
+        binding.siteRecyclerView.visibility = if (show) View.VISIBLE else View.INVISIBLE
+        binding.siteSwipeRefreshView.visibility = if (show) View.VISIBLE else View.INVISIBLE
+        binding.searchView.searchViewActionRightButton.visibility = if (show) View.VISIBLE else View.INVISIBLE
+        binding.searchButton.visibility = if (show) View.GONE else View.VISIBLE
+        binding.trackingLayout.visibility = if (show) View.GONE else View.VISIBLE
 
         if (show) {
             lastZoom = map.cameraPosition.zoom
             map.moveCamera(CameraUpdateFactory.zoomTo(21.0F))
             setSearchView()
-            searchLayout.setBackgroundResource(R.color.backgroundColorSite)
+            binding.searchView.searchLayout.setBackgroundResource(R.color.backgroundColorSite)
         } else {
             map.moveCamera(CameraUpdateFactory.zoomTo(lastZoom))
-            searchLayoutSearchEditText.text = null
-            searchLayout.setBackgroundResource(R.color.transparent)
+            binding.searchView.searchLayoutSearchEditText.text = null
+            binding.searchView.searchLayout.setBackgroundResource(R.color.transparent)
 
             hideLabel()
-            siteRecyclerView.visibility = View.GONE
+            binding.siteRecyclerView.visibility = View.GONE
             listener?.showBottomAppBar()
         }
     }
@@ -637,7 +643,7 @@ class MapFragment :
     private fun setTextTrackingButton(isOn: Boolean) {
         context?.let { context ->
             if (isOn) {
-                trackingImageView.setImageDrawable(
+                binding.trackingImageView.setImageDrawable(
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ic_tracking_on
@@ -646,8 +652,8 @@ class MapFragment :
                 startCounting()
             } else {
                 handler.removeCallbacks(run)
-                trackingTextView.text = getString(R.string.track)
-                trackingImageView.setImageDrawable(
+                binding.trackingTextView.text = getString(R.string.track)
+                binding.trackingImageView.setImageDrawable(
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ic_tracking_off
@@ -664,7 +670,7 @@ class MapFragment :
     private val run: Runnable = object : Runnable {
         override fun run() {
             context?.let {
-                trackingTextView.text = "${LocationTrackingManager.getDistance(trackingDb).setFormatLabel()}  ${LocationTrackingManager.getOnDutyTimeMinute(it)} min"
+                _binding?.trackingTextView?.text = "${LocationTrackingManager.getDistance(trackingDb).setFormatLabel()}  ${LocationTrackingManager.getOnDutyTimeMinute(it)} min"
             }
             handler.postDelayed(this, 20 * 1000L)
         }
@@ -684,12 +690,12 @@ class MapFragment :
 
     private fun updateUnsyncedCount(number: Int) {
         if (number == 0) {
-            unSyncedDpNumber.text = ""
-            unSyncedDpNumber.background =
+            binding.unSyncedDpNumber.text = ""
+            binding.unSyncedDpNumber.background =
                 ContextCompat.getDrawable(requireContext(), R.drawable.ic_check_circledp)
         } else {
-            unSyncedDpNumber.text = number.toString()
-            unSyncedDpNumber.background =
+            binding.unSyncedDpNumber.text = number.toString()
+            binding.unSyncedDpNumber.background =
                 ContextCompat.getDrawable(requireContext(), R.drawable.circle_unsynced)
         }
     }
@@ -832,7 +838,7 @@ class MapFragment :
                         getString(R.string.format_deploy_uploading)
                     }
                 }
-                statusView.onShow(msg)
+                binding.statusView.onShow(msg)
             }
 
             SyncInfo.Uploaded -> {
@@ -841,11 +847,11 @@ class MapFragment :
                 } else {
                     getString(R.string.format_deploys_uploaded)
                 }
-                statusView.onShowWithDelayed(msg)
+                binding.statusView.onShowWithDelayed(msg)
             }
             // else also waiting network
             else -> {
-                if (!isSites) statusView.onShowWithDelayed(getString(R.string.format_deploy_waiting_network))
+                if (!isSites) binding.statusView.onShowWithDelayed(getString(R.string.format_deploy_waiting_network))
             }
         }
     }
@@ -884,11 +890,11 @@ class MapFragment :
     }
 
     fun showButtonOnMap() {
-        buttonOnMapGroup.visibility = View.VISIBLE
+        binding.buttonOnMapGroup.visibility = View.VISIBLE
     }
 
     fun hideButtonOnMap() {
-        buttonOnMapGroup.visibility = View.GONE
+        binding.buttonOnMapGroup.visibility = View.GONE
     }
 
     override fun onResume() {
@@ -948,8 +954,8 @@ class MapFragment :
     }
 
     override fun onClicked(project: Project) {
-        projectRecyclerView.visibility = View.GONE
-        projectSwipeRefreshView.visibility = View.GONE
+        binding.projectRecyclerView.visibility = View.GONE
+        binding.projectSwipeRefreshView.visibility = View.GONE
 
         context?.let { context ->
             Preferences.getInstance(context).putInt(Preferences.SELECTED_PROJECT, project.id)
@@ -957,14 +963,14 @@ class MapFragment :
             mainViewModel.retrieveLocations()
         }
 
-        projectNameTextView.text = project.name
+        binding.projectNameTextView.text = project.name
         mainViewModel.combinedData()
 
-        if (siteRecyclerView.visibility == View.VISIBLE) {
-            searchLayout.visibility = View.VISIBLE
+        if (binding.siteRecyclerView.visibility == View.VISIBLE) {
+            binding.searchView.searchLayout.visibility = View.VISIBLE
         } else {
-            searchButton.visibility = View.VISIBLE
-            trackingLayout.visibility = View.VISIBLE
+            binding.searchButton.visibility = View.VISIBLE
+            binding.trackingLayout.visibility = View.VISIBLE
             showButtonOnMap()
             listener?.showBottomAppBar()
         }

--- a/app/src/main/java/org/rfcx/companion/view/map/SiteAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/map/SiteAdapter.kt
@@ -4,8 +4,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_site.view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemSiteBinding
 import org.rfcx.companion.entity.Stream
 import org.rfcx.companion.util.setFormatLabel
 import org.rfcx.companion.util.toTimeSinceStringAlternativeTimeAgo
@@ -23,9 +23,9 @@ class SiteAdapter(private val itemClickListener: (Stream, Boolean) -> Unit) :
         parent: ViewGroup,
         viewType: Int
     ): SiteAdapter.SiteAdapterViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_site, parent, false)
-        return SiteAdapterViewHolder(view)
+        val binding =
+            ItemSiteBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return SiteAdapterViewHolder(binding)
     }
 
     override fun getItemCount(): Int = items.size
@@ -43,12 +43,12 @@ class SiteAdapter(private val itemClickListener: (Stream, Boolean) -> Unit) :
         notifyDataSetChanged()
     }
 
-    inner class SiteAdapterViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val siteNameTextView = itemView.siteNameTextView
-        private val createdSiteNameTextView = itemView.createdSiteNameTextView
-        private val detailTextView = itemView.detailTextView
-        private val distanceTextView = itemView.distanceTextView
-        private val iconAddImageView = itemView.iconAddImageView
+    inner class SiteAdapterViewHolder(binding: ItemSiteBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val siteNameTextView = binding.siteNameTextView
+        private val createdSiteNameTextView = binding.createdSiteNameTextView
+        private val detailTextView = binding.detailTextView
+        private val distanceTextView = binding.distanceTextView
+        private val iconAddImageView = binding.iconAddImageView
 
         fun bind(site: SiteWithLastDeploymentItem) {
             createdSiteNameTextView.text =

--- a/app/src/main/java/org/rfcx/companion/view/profile/FeedbackActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/FeedbackActivity.kt
@@ -17,10 +17,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.activity_feedback.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.BaseListItem
+import org.rfcx.companion.databinding.ActivityFeedbackBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.entity.StatusEvent
 import org.rfcx.companion.repo.Firestore
@@ -35,16 +34,18 @@ class FeedbackActivity : AppCompatActivity() {
     private var pathListArray: List<String>? = null
     private var menuAll: Menu? = null
     private val analytics by lazy { Analytics(this) }
+    private lateinit var binding: ActivityFeedbackBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_feedback)
+        binding = ActivityFeedbackBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         setupToolbar()
         setTextFrom()
         setupFeedbackImages()
 
-        feedbackEditText.addTextChangedListener(object : TextWatcher {
+        binding.feedbackEditText.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
                 if (p0 != null) {
                     if (p0.isEmpty()) {
@@ -62,7 +63,7 @@ class FeedbackActivity : AppCompatActivity() {
     }
 
     private fun setupFeedbackImages() {
-        feedbackRecycler.apply {
+        binding.feedbackRecycler.apply {
             layoutManager = LinearLayoutManager(this@FeedbackActivity)
             adapter = feedbackImageAdapter
         }
@@ -159,10 +160,10 @@ class FeedbackActivity : AppCompatActivity() {
     private fun sendFeedback() {
         val sendFeedbackView = findViewById<View>(R.id.sendFeedbackView)
         val contextView = findViewById<View>(R.id.content)
-        val feedbackInput = feedbackEditText.text.toString()
+        val feedbackInput = binding.feedbackEditText.text.toString()
 
-        feedbackGroupView.visibility = View.GONE
-        feedbackProgressBar.visibility = View.VISIBLE
+        binding.feedbackGroupView.visibility = View.GONE
+        binding.feedbackProgressBar.visibility = View.VISIBLE
 
         setEnableSendFeedbackView(false)
         sendFeedbackView.hideKeyboard()
@@ -180,8 +181,8 @@ class FeedbackActivity : AppCompatActivity() {
 
                     finish()
                 } else {
-                    feedbackGroupView.visibility = View.VISIBLE
-                    feedbackProgressBar.visibility = View.GONE
+                    binding.feedbackGroupView.visibility = View.VISIBLE
+                    binding.feedbackProgressBar.visibility = View.GONE
                     analytics.trackSendFeedbackEvent(StatusEvent.FAILURE.id)
 
                     Snackbar.make(
@@ -199,11 +200,11 @@ class FeedbackActivity : AppCompatActivity() {
     }
 
     private fun setTextFrom() {
-        fromEmailTextView.text = getString(R.string.from, this.getEmailUser())
+        binding.fromEmailTextView.text = getString(R.string.from, this.getEmailUser())
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/profile/FeedbackImageAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/FeedbackImageAdapter.kt
@@ -2,16 +2,15 @@ package org.rfcx.companion.view.profile
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import kotlinx.android.synthetic.main.item_feedback_image.view.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.BaseListItem
+import org.rfcx.companion.databinding.ItemFeedbackImageBinding
 
 class FeedbackImageAdapter :
     ListAdapter<BaseListItem, RecyclerView.ViewHolder>(FeedbackImageAdapterDiffUtil()) {
@@ -89,9 +88,9 @@ class FeedbackImageAdapter :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         context = parent.context
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.item_feedback_image, parent, false)
-        return FeedbackImageAdapterViewHolder(view, onFeedbackImageAdapterClickListener)
+        val binding = ItemFeedbackImageBinding
+            .inflate(LayoutInflater.from(parent.context), parent, false)
+        return FeedbackImageAdapterViewHolder(binding, onFeedbackImageAdapterClickListener)
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -111,21 +110,21 @@ class FeedbackImageAdapter :
     }
 
     inner class FeedbackImageAdapterViewHolder(
-        itemView: View,
+        private val binding: ItemFeedbackImageBinding,
         private val onFeedbackImageAdapterClickListener: OnFeedbackImageAdapterClickListener?
-    ) : RecyclerView.ViewHolder(itemView) {
+    ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(imagePath: String) {
 
             val text: List<String>? = imagePath.split("/")
-            itemView.nameImageTextView.text = text?.get(text.size - 1) ?: ""
+            binding.nameImageTextView.text = text?.get(text.size - 1) ?: ""
 
-            Glide.with(itemView.imageFeedbackImageView)
+            Glide.with(binding.imageFeedbackImageView)
                 .load(imagePath)
                 .placeholder(R.drawable.bg_placeholder_light)
                 .error(R.drawable.bg_placeholder_light)
-                .into(itemView.imageFeedbackImageView)
+                .into(binding.imageFeedbackImageView)
 
-            itemView.deleteImageFeedbackButton.setOnClickListener {
+            binding.deleteImageFeedbackButton.setOnClickListener {
                 onFeedbackImageAdapterClickListener?.onDeleteImageClick(adapterPosition)
             }
         }

--- a/app/src/main/java/org/rfcx/companion/view/profile/ProfileFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/ProfileFragment.kt
@@ -12,10 +12,10 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.fragment.app.Fragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_profile.*
 import org.rfcx.companion.BuildConfig
 import org.rfcx.companion.MainActivityListener
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentProfileBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.entity.Theme
 import org.rfcx.companion.util.*
@@ -27,6 +27,9 @@ import org.rfcx.companion.view.profile.offlinemap.OfflineMapActivity
 class ProfileFragment : Fragment() {
     lateinit var listener: MainActivityListener
     private val analytics by lazy { context?.let { Analytics(it) } }
+
+    private var _binding: FragmentProfileBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -42,7 +45,13 @@ class ProfileFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_profile, container, false)
+        _binding = FragmentProfileBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -55,34 +64,34 @@ class ProfileFragment : Fragment() {
             this.resources.getStringArray(R.array.theme_less_than_10)
         }
 
-        userNameTextView.text = context.getUserNickname()
-        userLocationTextView.text = context?.getDefaultSiteName()
-        versionTextView.text = getString(
+        binding.userNameTextView.text = context.getUserNickname()
+        binding.userLocationTextView.text = context?.getDefaultSiteName()
+        binding.versionTextView.text = getString(
             R.string.version_app,
             BuildConfig.VERSION_NAME,
             BuildConfig.VERSION_CODE.toString()
         )
-        formatCoordinatesTextView.text = context?.getCoordinatesFormat()
-        themeSelectTextView.text = preferences?.getString(DISPLAY_THEME, themeOption[1])
+        binding.formatCoordinatesTextView.text = context?.getCoordinatesFormat()
+        binding.themeSelectTextView.text = preferences?.getString(DISPLAY_THEME, themeOption[1])
 
-        feedbackTextView.setOnClickListener {
+        binding.feedbackTextView.setOnClickListener {
             val intent = Intent(activity, FeedbackActivity::class.java)
             startActivityForResult(intent, REQUEST_CODE)
         }
 
-        logoutTextView.setOnClickListener {
+        binding.logoutTextView.setOnClickListener {
             listener.onLogout()
         }
 
-        offlineMapTextView.setOnClickListener {
+        binding.offlineMapTextView.setOnClickListener {
             context?.let { it1 -> OfflineMapActivity.startActivity(it1) }
         }
 
-        coordinatesLinearLayout.setOnClickListener {
+        binding.coordinatesLinearLayout.setOnClickListener {
             context?.let { it1 -> CoordinatesActivity.startActivity(it1) }
         }
 
-        darkThemeLinearLayout.setOnClickListener {
+        binding.darkThemeLinearLayout.setOnClickListener {
             val builder = context?.let { MaterialAlertDialogBuilder(it, R.style.BaseAlertDialog) }
             val selectedRadioItem =
                 themeOption.indexOf(preferences?.getString(DISPLAY_THEME, themeOption[1]))
@@ -110,7 +119,7 @@ class ProfileFragment : Fragment() {
                                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
                             }
                         }
-                        themeSelectTextView.text = themeOption[which]
+                        binding.themeSelectTextView.text = themeOption[which]
                         dialog.dismiss()
                     }
                 )
@@ -119,12 +128,12 @@ class ProfileFragment : Fragment() {
                 }
                 builder.show()
             }
-            locationGroupLinearLayout.setOnClickListener {
+            binding.locationGroupLinearLayout.setOnClickListener {
                 context?.let { it1 -> ProjectActivity.startActivity(it1) }
             }
         }
 
-        locationGroupLinearLayout.setOnClickListener {
+        binding.locationGroupLinearLayout.setOnClickListener {
             context?.let { it1 -> ProjectActivity.startActivity(it1) }
         }
     }
@@ -141,7 +150,7 @@ class ProfileFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        formatCoordinatesTextView.text = context?.getCoordinatesFormat()
+        binding.formatCoordinatesTextView.text = context?.getCoordinatesFormat()
         analytics?.trackScreen(Screen.PROFILE)
     }
 

--- a/app/src/main/java/org/rfcx/companion/view/profile/coordinates/CoordinatesActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/coordinates/CoordinatesActivity.kt
@@ -5,9 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.activity_coordinates.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ActivityCoordinatesBinding
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.Analytics
 import org.rfcx.companion.util.Preferences
@@ -15,28 +14,30 @@ import org.rfcx.companion.util.getCoordinatesFormat
 
 class CoordinatesActivity : AppCompatActivity() {
     private val analytics by lazy { Analytics(this) }
+    private lateinit var binding: ActivityCoordinatesBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_coordinates)
+        binding = ActivityCoordinatesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setupToolbar()
 
         val preferences = Preferences.getInstance(this)
         this.getCoordinatesFormat()?.let { showChecker(it) }
 
-        ddLayout.setOnClickListener {
+        binding.ddLayout.setOnClickListener {
             preferences.putString(Preferences.COORDINATES_FORMAT, DD_FORMAT)
             showChecker(DD_FORMAT)
             finish()
         }
 
-        ddmLayout.setOnClickListener {
+        binding.ddmLayout.setOnClickListener {
             preferences.putString(Preferences.COORDINATES_FORMAT, DDM_FORMAT)
             showChecker(DDM_FORMAT)
             finish()
         }
 
-        dmsLayout.setOnClickListener {
+        binding.dmsLayout.setOnClickListener {
             preferences.putString(Preferences.COORDINATES_FORMAT, DMS_FORMAT)
             showChecker(DMS_FORMAT)
             finish()
@@ -47,25 +48,25 @@ class CoordinatesActivity : AppCompatActivity() {
         analytics.trackChangeCoordinatesEvent(format)
         when (format) {
             DD_FORMAT -> {
-                checkDDImageView.visibility = View.VISIBLE
-                checkDDMImageView.visibility = View.INVISIBLE
-                checkDMSImageView.visibility = View.INVISIBLE
+                binding.checkDDImageView.visibility = View.VISIBLE
+                binding.checkDDMImageView.visibility = View.INVISIBLE
+                binding.checkDMSImageView.visibility = View.INVISIBLE
             }
             DDM_FORMAT -> {
-                checkDDImageView.visibility = View.INVISIBLE
-                checkDDMImageView.visibility = View.VISIBLE
-                checkDMSImageView.visibility = View.INVISIBLE
+                binding.checkDDImageView.visibility = View.INVISIBLE
+                binding.checkDDMImageView.visibility = View.VISIBLE
+                binding.checkDMSImageView.visibility = View.INVISIBLE
             }
             DMS_FORMAT -> {
-                checkDDImageView.visibility = View.INVISIBLE
-                checkDDMImageView.visibility = View.INVISIBLE
-                checkDMSImageView.visibility = View.VISIBLE
+                binding.checkDDImageView.visibility = View.INVISIBLE
+                binding.checkDDMImageView.visibility = View.INVISIBLE
+                binding.checkDMSImageView.visibility = View.VISIBLE
             }
         }
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectActivity.kt
@@ -6,9 +6,8 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.activity_location_group.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ActivityLocationGroupBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.util.Preferences
@@ -18,10 +17,12 @@ class ProjectActivity : AppCompatActivity(), ProjectProtocol {
 
     // For detail page to edit location group
     private var project: String? = null
+    private lateinit var binding: ActivityLocationGroupBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_location_group)
+        binding = ActivityLocationGroupBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         setupToolbar()
 
@@ -57,12 +58,12 @@ class ProjectActivity : AppCompatActivity(), ProjectProtocol {
 
     private fun startFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-            .replace(locationGroupContainer.id, fragment)
+            .replace(binding.locationGroupContainer.id, fragment)
             .commit()
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectAdapter.kt
@@ -5,8 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_location_group.view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemLocationGroupBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.Screen
 import org.rfcx.companion.entity.isGuest
@@ -25,9 +25,9 @@ class ProjectAdapter(private val projectListener: ProjectListener) :
         parent: ViewGroup,
         viewType: Int
     ): ProjectViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_location_group, parent, false)
-        return ProjectViewHolder(view)
+        val binding =
+            ItemLocationGroupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ProjectViewHolder(binding)
     }
 
     override fun getItemCount(): Int = items.size
@@ -39,10 +39,10 @@ class ProjectAdapter(private val projectListener: ProjectListener) :
         }
     }
 
-    inner class ProjectViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val projectTextView = itemView.locationGroupTextView
-        private val checkImageView = itemView.checkImageView
-        private val lockImageView = itemView.lockImageView
+    inner class ProjectViewHolder(binding: ItemLocationGroupBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val projectTextView = binding.locationGroupTextView
+        private val checkImageView = binding.checkImageView
+        private val lockImageView = binding.lockImageView
 
         fun bind(project: Project) {
             if (screen != Screen.PROFILE.id) {

--- a/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/locationgroup/ProjectFragment.kt
@@ -9,13 +9,12 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import io.realm.Realm
-import kotlinx.android.synthetic.main.fragment_location_group.*
-import kotlinx.android.synthetic.main.fragment_location_group.projectSwipeRefreshView
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.FragmentLocationGroupBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.response.ProjectResponse
 import org.rfcx.companion.localdb.ProjectDb
@@ -38,6 +37,10 @@ class ProjectFragment :
     private var screen: String? = null
 
     private lateinit var locationGroupLiveData: LiveData<List<Project>>
+
+    private var _binding: FragmentLocationGroupBinding? = null
+    private val binding get() = _binding!!
+
     private val locationGroupObserve = Observer<List<Project>> {
         projectAdapter.apply {
             items = projectGroupDb.getProjects()
@@ -61,18 +64,24 @@ class ProjectFragment :
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_location_group, container, false)
+        _binding = FragmentLocationGroupBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        locationGroupRecyclerView.apply {
+        binding.locationGroupRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = projectAdapter
         }
 
-        projectSwipeRefreshView.apply {
+        binding.projectSwipeRefreshView.apply {
             setOnRefreshListener(this@ProjectFragment)
             setColorSchemeResources(R.color.colorPrimary)
         }
@@ -94,7 +103,7 @@ class ProjectFragment :
 
     private fun getProjects() {
         locationGroupLiveData =
-            Transformations.map(projectGroupDb.getAllResultsAsync().asLiveData()) {
+            projectGroupDb.getAllResultsAsync().asLiveData().map {
                 it
             }
         locationGroupLiveData.observeForever(locationGroupObserve)
@@ -108,7 +117,7 @@ class ProjectFragment :
                         Toast.makeText(context, R.string.error_has_occurred, Toast.LENGTH_SHORT)
                             .show()
                     }
-                    projectSwipeRefreshView.isRefreshing = false
+                    _binding?.projectSwipeRefreshView?.isRefreshing = false
                 }
 
                 override fun onResponse(
@@ -141,7 +150,7 @@ class ProjectFragment :
                         response.body()?.let { projectsRes ->
                             projectGroupDb.deleteProjectsByCoreId(projectsRes) // remove project with these coreIds
                         }
-                        projectSwipeRefreshView.isRefreshing = false
+                        _binding?.projectSwipeRefreshView?.isRefreshing = false
                     }
                 }
             })
@@ -157,7 +166,7 @@ class ProjectFragment :
 
     override fun onRefresh() {
         retrieveProjects(requireContext())
-        projectSwipeRefreshView.isRefreshing = true
+        binding.projectSwipeRefreshView.isRefreshing = true
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/OfflineMapActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/OfflineMapActivity.kt
@@ -5,21 +5,23 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.activity_offline_map.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ActivityOfflineMapBinding
 
 class OfflineMapActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityOfflineMapBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_offline_map)
+        binding = ActivityOfflineMapBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setupToolbar()
 
         startFragment(OfflineMapFragment.newInstance())
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
@@ -34,7 +36,7 @@ class OfflineMapActivity : AppCompatActivity() {
 
     private fun startFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-            .replace(offlineMapContainer.id, fragment)
+            .replace(binding.offlineMapContainer.id, fragment)
             .commit()
     }
 

--- a/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/OfflineMapFragment.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/OfflineMapFragment.kt
@@ -10,13 +10,13 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.fragment_offline_map.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.FragmentOfflineMapBinding
 import org.rfcx.companion.entity.OfflineMapState
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.repo.api.CoreApiHelper
@@ -41,13 +41,22 @@ class OfflineMapFragment : Fragment(), ProjectOfflineMapListener {
     lateinit var projectAdapter: ProjectOfflineMapAdapter
     private var project: Project? = null
 
+    private var _binding: FragmentOfflineMapBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_offline_map, container, false)
+        _binding = FragmentOfflineMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -117,7 +126,7 @@ class OfflineMapFragment : Fragment(), ProjectOfflineMapListener {
     }
 
     private fun setupAdapter() {
-        with(projectsRecyclerView) {
+        with(binding.projectsRecyclerView) {
             layoutManager = LinearLayoutManager(context)
             DividerItemDecoration(
                 context,

--- a/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/ProjectOfflineMapAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/ProjectOfflineMapAdapter.kt
@@ -6,8 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_location_group.view.*
-import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemLocationGroupBinding
 import org.rfcx.companion.entity.OfflineMapState
 import org.rfcx.companion.entity.Project
 
@@ -31,9 +30,9 @@ class ProjectOfflineMapAdapter(
         parent: ViewGroup,
         viewType: Int
     ): ProjectOfflineMapAdapter.ProjectOfflineMapViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_location_group, parent, false)
-        return ProjectOfflineMapViewHolder(view)
+        val binding =
+            ItemLocationGroupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ProjectOfflineMapViewHolder(binding)
     }
 
     override fun onBindViewHolder(
@@ -41,7 +40,7 @@ class ProjectOfflineMapAdapter(
         position: Int
     ) {
         val project = items[position]
-        with(holder.itemView) {
+        with(holder.binding) {
             locationGroupTextView.text = project.name
 
             downloadButton.setOnClickListener {
@@ -52,7 +51,7 @@ class ProjectOfflineMapAdapter(
                 projectOfflineMapListener.onDeleteClicked(project)
             }
 
-            setViewMapOffline(this, project)
+            setViewMapOffline(holder.binding, project)
 
             if (hideDownloadButton) {
                 downloadButton.isEnabled = false
@@ -68,7 +67,7 @@ class ProjectOfflineMapAdapter(
     ) {
         super.onBindViewHolder(holder, position, payloads)
         if (payloads.firstOrNull() != null) {
-            with(holder.itemView) {
+            with(holder.binding) {
                 (payloads.first() as Bundle).getInt(PROGRESS).also {
                     downloadedTextView.isVisible = it < 99
                     downloadedTextView.text = "$it %"
@@ -87,14 +86,14 @@ class ProjectOfflineMapAdapter(
 
     override fun getItemCount(): Int = items.size
 
-    inner class ProjectOfflineMapViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+    inner class ProjectOfflineMapViewHolder(val binding: ItemLocationGroupBinding) : RecyclerView.ViewHolder(binding.root)
 
-    private fun setViewMapOffline(itemView: View, project: Project) {
-        val offlineMapProgress = itemView.offlineMapProgress
-        val downloadedTextView = itemView.downloadedTextView
-        val downloadButton = itemView.downloadButton
-        val deleteButton = itemView.deleteButton
-        val unavailableTextView = itemView.unavailableTextView
+    private fun setViewMapOffline(binding: ItemLocationGroupBinding, project: Project) {
+        val offlineMapProgress = binding.offlineMapProgress
+        val downloadedTextView = binding.downloadedTextView
+        val downloadButton = binding.downloadButton
+        val deleteButton = binding.deleteButton
+        val unavailableTextView = binding.unavailableTextView
 
         when (project.offlineMapState) {
             OfflineMapState.DOWNLOAD_STATE.key -> {

--- a/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/ProjectOfflineMapViewModel.kt
+++ b/app/src/main/java/org/rfcx/companion/view/profile/offlinemap/ProjectOfflineMapViewModel.kt
@@ -30,9 +30,7 @@ class ProjectOfflineMapViewModel(
 
     private fun fetchLiveData() {
         projectsLiveData =
-            Transformations.map(
-                projectOfflineMapRepository.getAllProjectResultsAsync().asLiveData()
-            ) {
+            projectOfflineMapRepository.getAllProjectResultsAsync().asLiveData().map {
                 it
             }
         projectsLiveData.observeForever(projectsObserve)

--- a/app/src/main/java/org/rfcx/companion/view/project/ProjectSelectActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/project/ProjectSelectActivity.kt
@@ -10,10 +10,10 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import kotlinx.android.synthetic.main.activity_project_select.*
 import org.rfcx.companion.MainActivity
 import org.rfcx.companion.R
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityProjectSelectBinding
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
@@ -39,9 +39,12 @@ class ProjectSelectActivity :
 
     private var selectedProject = -1
 
+    private lateinit var binding: ActivityProjectSelectBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_project_select)
+        binding = ActivityProjectSelectBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         try {
             if (preferences.getInt(Preferences.SELECTED_PROJECT) != -1) {
@@ -62,23 +65,23 @@ class ProjectSelectActivity :
             addProjectsToAdapter()
         }
 
-        projectSwipeRefreshView.apply {
+        binding.projectSwipeRefreshView.apply {
             setOnRefreshListener(this@ProjectSelectActivity)
             setColorSchemeResources(R.color.colorPrimary)
         }
 
-        projectView.apply {
+        binding.projectView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = projectSelectAdapter
         }
 
-        selectProjectButton.setOnClickListener {
+        binding.selectProjectButton.setOnClickListener {
             preferences.putInt(Preferences.SELECTED_PROJECT, selectedProject)
             MainActivity.startActivity(this)
             finish()
         }
 
-        logoutButton.setOnClickListener {
+        binding.logoutButton.setOnClickListener {
             DeploymentCleanupWorker.stopAllWork(this)
             this.logout()
             LocationTrackingManager.set(this, false)
@@ -111,9 +114,9 @@ class ProjectSelectActivity :
                         hideLoading()
                         it.data?.let { projects ->
                             if (projects.isEmpty()) {
-                                noContentTextView.visibility = View.VISIBLE
+                                binding.noContentTextView.visibility = View.VISIBLE
                             } else {
-                                noContentTextView.visibility = View.GONE
+                                binding.noContentTextView.visibility = View.GONE
                             }
                         }
                         addProjectsToAdapter()
@@ -137,12 +140,12 @@ class ProjectSelectActivity :
     }
 
     private fun showLoading() {
-        noContentTextView.visibility = View.GONE
-        projectSwipeRefreshView.isRefreshing = true
+        binding.noContentTextView.visibility = View.GONE
+        binding.projectSwipeRefreshView.isRefreshing = true
     }
 
     private fun hideLoading() {
-        projectSwipeRefreshView.isRefreshing = false
+        binding.projectSwipeRefreshView.isRefreshing = false
     }
 
     override fun onRefresh() {
@@ -158,7 +161,7 @@ class ProjectSelectActivity :
 
     override fun onClicked(project: Project) {
         selectedProject = project.id
-        selectProjectButton.isEnabled = true
+        binding.selectProjectButton.isEnabled = true
     }
 
     override fun onLockImageClicked() {

--- a/app/src/main/java/org/rfcx/companion/view/project/ProjectSelectAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/project/ProjectSelectAdapter.kt
@@ -5,8 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_location_group.view.*
 import org.rfcx.companion.R
+import org.rfcx.companion.databinding.ItemLocationGroupBinding
 import org.rfcx.companion.entity.Permissions
 import org.rfcx.companion.entity.Project
 import org.rfcx.companion.entity.isGuest
@@ -23,17 +23,17 @@ class ProjectSelectAdapter(private val projectSelectListener: ProjectListener) :
         }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProjectSelectViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_location_group, parent, false)
-        return ProjectSelectViewHolder(view)
+        val binding =
+            ItemLocationGroupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ProjectSelectViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ProjectSelectViewHolder, position: Int) {
 
         if (selectedPosition == position) {
-            holder.itemView.checkImageView.visibility = View.VISIBLE
+            holder.binding.checkImageView.visibility = View.VISIBLE
         } else {
-            holder.itemView.checkImageView.visibility = View.GONE
+            holder.binding.checkImageView.visibility = View.GONE
         }
 
         holder.bind(items[position])
@@ -61,9 +61,9 @@ class ProjectSelectAdapter(private val projectSelectListener: ProjectListener) :
 
     override fun getItemCount(): Int = items.size
 
-    inner class ProjectSelectViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val locationGroupTextView = itemView.locationGroupTextView
-        private val lockImageView = itemView.lockImageView
+    inner class ProjectSelectViewHolder(val binding: ItemLocationGroupBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val locationGroupTextView = binding.locationGroupTextView
+        private val lockImageView = binding.lockImageView
 
         fun bind(project: Project) {
             locationGroupTextView.text = project.name ?: itemView.context.getString(R.string.none)

--- a/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksActivity.kt
+++ b/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksActivity.kt
@@ -12,11 +12,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.TransitionManager
 import androidx.work.WorkInfo
-import kotlinx.android.synthetic.main.activity_unsynced_works.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.UnsyncedWorksViewItem
 import org.rfcx.companion.base.ViewModelFactory
+import org.rfcx.companion.databinding.ActivityUnsyncedWorksBinding
 import org.rfcx.companion.repo.api.CoreApiHelper
 import org.rfcx.companion.repo.api.CoreApiServiceImpl
 import org.rfcx.companion.repo.api.DeviceApiHelper
@@ -29,6 +28,7 @@ import org.rfcx.companion.view.map.SyncInfo
 class UnsyncedWorksActivity : AppCompatActivity(), UnsyncedWorkListener {
 
     private val unsyncedWorksAdapter by lazy { UnsyncedWorksAdapter(this) }
+    private lateinit var binding: ActivityUnsyncedWorksBinding
 
     private lateinit var viewModel: UnsyncedWorksViewModel
 
@@ -77,32 +77,33 @@ class UnsyncedWorksActivity : AppCompatActivity(), UnsyncedWorkListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_unsynced_works)
+        binding = ActivityUnsyncedWorksBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         setViewModel()
         setObserve()
 
         setupToolbar()
 
-        unsyncedRecyclerView.apply {
+        binding.unsyncedRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = unsyncedWorksAdapter
         }
 
-        confirmButton.setOnClickListener {
+        binding.confirmButton.setOnClickListener {
             viewModel.syncDeployment()
             it.isEnabled = false
         }
     }
 
     private fun showBanner() {
-        TransitionManager.beginDelayedTransition(banner, UnsyncedBannerTransition())
-        banner.visibility = View.VISIBLE
+        TransitionManager.beginDelayedTransition(binding.banner, UnsyncedBannerTransition())
+        binding.banner.visibility = View.VISIBLE
     }
 
     private fun hideBanner() {
-        TransitionManager.beginDelayedTransition(banner, UnsyncedBannerTransition())
-        banner.visibility = View.GONE
+        TransitionManager.beginDelayedTransition(binding.banner, UnsyncedBannerTransition())
+        binding.banner.visibility = View.GONE
     }
 
     private fun setViewModel() {
@@ -131,7 +132,7 @@ class UnsyncedWorksActivity : AppCompatActivity(), UnsyncedWorkListener {
     }
 
     private fun setupToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbarLayout.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
@@ -156,15 +157,15 @@ class UnsyncedWorksActivity : AppCompatActivity(), UnsyncedWorkListener {
     private fun setUnsyncedText(deploymentCount: Int) {
         when (deploymentCount) {
             0 -> {
-                bannerText.text = getString(R.string.all_works_synced)
+                binding.bannerText.text = getString(R.string.all_works_synced)
                 unsyncedWorksAdapter.setUnsynceds(listOf())
-                noContentTextView.visibility = View.VISIBLE
-                unsyncedIndicator.visibility = View.GONE
+                binding.noContentTextView.visibility = View.VISIBLE
+                binding.unsyncedIndicator.visibility = View.GONE
                 hideBanner()
             }
             else -> {
-                bannerText.text = getString(R.string.unsynced_deployment_text, deploymentCount)
-                noContentTextView.visibility = View.GONE
+                binding.bannerText.text = getString(R.string.unsynced_deployment_text, deploymentCount)
+                binding.noContentTextView.visibility = View.GONE
                 showBanner()
             }
         }
@@ -209,15 +210,15 @@ class UnsyncedWorksActivity : AppCompatActivity(), UnsyncedWorkListener {
     }
 
     private fun showSyncingState() {
-        confirmButton.text = getString(R.string.syncing)
-        confirmButton.isEnabled = false
-        unsyncedIndicator.visibility = View.VISIBLE
+        binding.confirmButton.text = getString(R.string.syncing)
+        binding.confirmButton.isEnabled = false
+        binding.unsyncedIndicator.visibility = View.VISIBLE
     }
 
     private fun showSyncedState() {
-        confirmButton.text = getString(R.string.sync)
-        confirmButton.isEnabled = true
-        unsyncedIndicator.visibility = View.GONE
+        binding.confirmButton.text = getString(R.string.sync)
+        binding.confirmButton.isEnabled = true
+        binding.unsyncedIndicator.visibility = View.GONE
     }
 
     override fun onDeploymentClick(id: Int) {

--- a/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksAdapter.kt
+++ b/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksAdapter.kt
@@ -5,10 +5,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.item_unsynced_deployment.view.*
-import kotlinx.android.synthetic.main.item_unsynced_deployment.view.deleteButton
 import org.rfcx.companion.R
 import org.rfcx.companion.adapter.UnsyncedWorksViewItem
+import org.rfcx.companion.databinding.ItemUnsyncedDeploymentBinding
 import org.rfcx.companion.util.toTimeAgo
 
 class UnsyncedWorksAdapter(private val unsyncedDeploymentListener: UnsyncedWorkListener) :
@@ -39,8 +38,9 @@ class UnsyncedWorksAdapter(private val unsyncedDeploymentListener: UnsyncedWorkL
     ): RecyclerView.ViewHolder {
         return when (viewType) {
             DEPLOYMENT_ITEM -> UnsyncedDeploymentViewHolder(
-                LayoutInflater.from(parent.context)
-                    .inflate(R.layout.item_unsynced_deployment, parent, false)
+                ItemUnsyncedDeploymentBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
             )
             else -> HeaderItemViewHolder(
                 LayoutInflater.from(parent.context)
@@ -58,11 +58,11 @@ class UnsyncedWorksAdapter(private val unsyncedDeploymentListener: UnsyncedWorkL
 
     override fun getItemCount(): Int = listOfUnsynced.size
 
-    inner class UnsyncedDeploymentViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val name = itemView.unsyncedName
-        private val error = itemView.unsyncedError
-        private val deployedAt = itemView.deployedAt
-        val deleteButton = itemView.deleteButton
+    inner class UnsyncedDeploymentViewHolder(binding: ItemUnsyncedDeploymentBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val name = binding.unsyncedName
+        private val error = binding.unsyncedError
+        private val deployedAt = binding.deployedAt
+        val deleteButton = binding.deleteButton
 
         fun bind(deployment: UnsyncedWorksViewItem.Deployment) {
             name.text = deployment.name

--- a/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksViewModel.kt
+++ b/app/src/main/java/org/rfcx/companion/view/unsynced/UnsyncedWorksViewModel.kt
@@ -29,9 +29,7 @@ class UnsyncedWorksViewModel(
     }
 
     private fun fetchLiveData() {
-        deploymentLiveData = Transformations.map(
-            repository.getAllDeploymentLocalResultsAsync().asLiveData()
-        ) { it }
+        deploymentLiveData = repository.getAllDeploymentLocalResultsAsync().asLiveData().map { it }
         deploymentLiveData.observeForever(deploymentObserve)
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,9 @@
         app:fabAlignmentMode="center"
         app:titleMarginStart="0dp">
 
-        <include layout="@layout/layout_bottom_navigation_menu" />
+        <include
+            android:id="@+id/bottomNavigationMenu"
+            layout="@layout/layout_bottom_navigation_menu" />
 
     </com.google.android.material.bottomappbar.BottomAppBar>
 

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -86,7 +86,7 @@
         android:layout_height="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchLayout">
+        app:layout_constraintTop_toBottomOf="@id/searchView">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/siteRecyclerView"
@@ -187,6 +187,7 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <include
+        android:id="@+id/searchView"
         layout="@layout/layout_search_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_map_picker.xml
+++ b/app/src/main/res/layout/fragment_map_picker.xml
@@ -94,6 +94,7 @@
         app:layout_constraintTop_toTopOf="@id/selectLocationTextView" />
 
     <include
+        android:id="@+id/searchView"
         layout="@layout/layout_search_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -109,6 +110,6 @@
         android:elevation="10dp"
         android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchLayout" />
+        app:layout_constraintTop_toBottomOf="@+id/searchView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_set_deployment_site.xml
+++ b/app/src/main/res/layout/fragment_set_deployment_site.xml
@@ -12,6 +12,7 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
     <include
+        android:id="@+id/searchView"
         layout="@layout/layout_search_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -24,7 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="@dimen/margin_padding_normal"
-        app:layout_constraintTop_toBottomOf="@id/searchLayout"
+        app:layout_constraintTop_toBottomOf="@id/searchView"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.recyclerview.widget.RecyclerView

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    // Bumped 1.6.21 -> 1.8.10 (2026-07-15): posthog-android is compiled with
+    // Kotlin 1.8 metadata, which a 1.6 compiler cannot read. 1.8.10 matches the
+    // guardian-app-android app, is supported by AGP 8.1.2 / Gradle 8.0, and works
+    // with Realm 10.15.1 (a kapt bytecode transformer, Kotlin-tolerant).
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
     }


### PR DESCRIPTION
## What & why

The merged PostHog PR (#741) forced a Kotlin bump to **1.8.10** (posthog-android 3.x metadata can't be read by Kotlin 1.6). Kotlin 1.8 **removes** the `kotlin-android-extensions` Gradle plugin, so `develop` no longer builds — the `kotlinx.android.synthetic.*` "synthetic view" imports are gone. This PR migrates the app off synthetics onto **ViewBinding** so `develop` compiles + passes CI again.

Builds on the existing groundwork commits on this branch (ktlint pre-existing fixes, posthog pin 3.22.0, Kotlin 1.8.10 bump).

## Changes

**ViewBinding migration (all 44 synthetic files)**
- Every `kotlinx.android.synthetic` import removed; view access routed through generated `*Binding` classes.
- Covers all four patterns: plain Activity, Fragment (`_binding`/`onDestroyView` nulling), `.view.*` RecyclerView adapters, and the custom-View (`StatusView`) inflate form.
- `grep kotlinx.android.synthetic app/src/main/java` → **0 results**.

**build.gradle**
- Remove `apply plugin: 'kotlin-android-extensions'`; add `buildFeatures { viewBinding true; buildConfig true }`.
- Align **all** Kotlin compile tasks (incl. `kaptGenerateStubs`) to `jvmTarget 1.8` — Kotlin 1.8 otherwise defaults kapt stub generation to JDK 17 while javac stays 1.8, causing a target-mismatch failure.
- Move `POSTHOG_API_KEY` / `POSTHOG_HOST` `buildConfigField`s from the `common` flavor to `defaultConfig` so the **CI-built `internalDevelop`** variant (a different flavor in the same `mode` dimension) actually receives them.

**Transitive Kotlin-1.8 / posthog fallout (behavior-identical)**
- lifecycle 2.6 removed `Transformations.map` → `LiveData.map` (`androidx.lifecycle.map`) in `MainViewModel` + 6 ViewModels/screens.
- lifecycle 2.6 `ViewModelProvider.Factory.create<T : ViewModel>` (non-null bound) in `ViewModelFactory`.
- okhttp 4.x (pulled transitively by posthog): `MediaType.parse` / `RequestBody.create` → ktx extensions; `Response.request()` → `request` val (`ImageSyncWorker`, `TrackingSyncWorker`, `TokenAuthenticator`).

**Layout XML — minimal, id-only additions** (noted because these are the only XML edits)
- Added `android:id` to the `<include>` of `layout_search_view` (`@id/searchView`) in `fragment_map`, `fragment_map_picker`, `fragment_set_deployment_site`, and to `layout_bottom_navigation_menu` (`@id/bottomNavigationMenu`) in `activity_main`, so ViewBinding exposes the included children.
- Repointed the sibling `layout_constraintTop_toBottomOf` references in those three fragments from `@id/searchLayout` to the new include id `@id/searchView`.
- (The `toolbar_default` includes already carried `@id/toolbarLayout` in the repo, so no XML change was needed there.)

## Validation

Local toolchain on the build host (Android SDK + JDK 17), then CI:
- ✅ `./gradlew assembleInternalDevelopDebug`
- ✅ `./gradlew ktlintCheck` (CI's first gate)
- ✅ `./gradlew lintInternalDevelopDebug`
- ✅ **On-device smoke test (Pixel 7):** installed the debug APK; `LoginActivity` renders every migrated ViewBinding view (email/password fields, sign-in + Google buttons, logo); tapping **Sign In** runs the `binding.signInButton` handler → input validation → Auth0 web flow. **Zero `FATAL`/`AndroidRuntime` crashes across the session.**

Analytics behavior (PostHog init + identify-by-email) is unchanged from #741.

## Ask for reviewers
Please do a maintainer on-device pass of the deeper authenticated screens (map, deployment flow, adapters, dialogs) before release — the migration is behavior-identical and locally smoke-tested, but a human walkthrough of the full flows is the final check.
